### PR TITLE
Improve performance of parsing compiler arguments

### DIFF
--- a/Sources/Requests/BazelEnvPlaceholder.swift
+++ b/Sources/Requests/BazelEnvPlaceholder.swift
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+enum BazelEnvPlaceholder: String {
+    case execRoot = "__BAZEL_EXECUTION_ROOT__"
+    case sdkRoot = "__BAZEL_XCODE_SDKROOT__"
+    case devDir = "__BAZEL_XCODE_DEVELOPER_DIR__"
+}

--- a/Sources/Requests/TextDocumentSourceKitOptionsHandler.swift
+++ b/Sources/Requests/TextDocumentSourceKitOptionsHandler.swift
@@ -278,14 +278,6 @@ final class TextDocumentSourceKitOptionsHandler {
                 continue
             }
 
-            // Skip index store path arguments (handled later)
-            if arg.contains("-index-store-path") {
-                if index + 1 < count, rawArguments[index + 1].contains("indexstore") {
-                    index += 2
-                    continue
-                }
-            }
-
             // Skip const-gather-protocols arguments
             if arg.contains("-Xfrontend"), index + 1 < count {
                 let nextArg = rawArguments[index + 1]

--- a/Sources/Requests/TextDocumentSourceKitOptionsHandler.swift
+++ b/Sources/Requests/TextDocumentSourceKitOptionsHandler.swift
@@ -202,28 +202,11 @@ final class TextDocumentSourceKitOptionsHandler {
         // Process compiler arguments with transformations
         let processedArgs = try processCompilerArguments(
             rawArguments: lines,
-            language: language
+            language: language,
+            contentToQuery: contentToQuery
         )
 
         lines = processedArgs
-
-        if language == .objective_c, contentToQuery.hasSuffix(".m") {
-            // For Obj-C, add additional arguments that are needed for indexing
-            // that Bazel / SK doesn't add by default, and adjust other inconsistencies
-            // with Xcode index builds.
-            removeArgSingle("-c", &lines)
-            lines.insert("-x", at: 0)
-            lines.insert("objective-c", at: 1)
-            lines.append("-index-store-path")
-            lines.append(initializedConfig.indexStorePath)
-            lines.append("-working-directory")
-            lines.append(initializedConfig.rootUri)
-        } else if language == .swift {
-            // For Swift, swap the index store arg with the global cache.
-            // Bazel handles this a bit differently internally, which is why
-            // we need to do this.
-            editArg("-index-store-path", initializedConfig.indexStorePath, &lines)
-        }
 
         logger.info("Finished processing compiler arguments")
 
@@ -233,7 +216,8 @@ final class TextDocumentSourceKitOptionsHandler {
     /// Processes compiler arguments with transformations
     func processCompilerArguments(
         rawArguments: [String],
-        language _: Language
+        language: Language,
+        contentToQuery: String
     ) throws -> [String] {
         var compilerArguments: [String] = []
 
@@ -246,28 +230,26 @@ final class TextDocumentSourceKitOptionsHandler {
         var index = 0
         let count = rawArguments.count
 
+        let indexingObjCHeader = language == .objective_c && contentToQuery.hasSuffix(".m")
+
+        if indexingObjCHeader {
+            // Xcode index builds adds these arguments to the beginning.
+            compilerArguments.append("-x")
+            compilerArguments.append("objective-c")
+        }
+
+        // Filtering/processing arguments that are either not needed for indexing or cause problems with it
         while index < count {
             let arg = rawArguments[index]
 
-            // Skip swiftc executable and wrapper arguments
-            if arg.contains("-Xwrapped-swift") || arg.hasSuffix("worker") || arg.hasPrefix("swiftc") {
+            // Skip wrapper arguments
+            if arg.hasPrefix("-Xwrapped-swift") {
                 index += 1
                 continue
             }
 
-            // skip clang
-            if arg.contains("wrapped_clang") {
-                index += 1
-                continue
-            }
-
-            // Replace execution root placeholder
-            if arg.contains("__BAZEL_EXECUTION_ROOT__") {
-                let transformedArg = arg.replacingOccurrences(
-                    of: "__BAZEL_EXECUTION_ROOT__",
-                    with: rootUri
-                )
-                compilerArguments.append(transformedArg)
+            // Just aligning inconsistencies with Xcode index Obj-C builds.
+            if arg == "-c" && indexingObjCHeader {
                 index += 1
                 continue
             }
@@ -278,53 +260,13 @@ final class TextDocumentSourceKitOptionsHandler {
                 continue
             }
 
-            // Skip const-gather-protocols arguments
-            if arg.contains("-Xfrontend"), index + 1 < count {
-                let nextArg = rawArguments[index + 1]
-                if nextArg.contains("-const-gather-protocols-file")
-                    || nextArg.contains("const_protocols_to_gather.json")
-                {
-                    index += 2
-                    continue
-                }
-            }
-
-            // Replace SDK placeholder
-            if arg.contains("__BAZEL_XCODE_SDKROOT__") {
-                let transformedArg = arg.replacingOccurrences(
-                    of: "__BAZEL_XCODE_SDKROOT__",
-                    with: sdkRoot
-                )
-                compilerArguments.append(transformedArg)
-                index += 1
-                continue
-            }
-
-            // replace Xcode Developer Directory
-            if arg.contains("__BAZEL_XCODE_DEVELOPER_DIR__") {
-                let transformedArg = arg.replacingOccurrences(
-                    of: "__BAZEL_XCODE_DEVELOPER_DIR__",
-                    with: devDir
-                )
-                compilerArguments.append(transformedArg)
-                index += 1
-                continue
-            }
-
-            // Transform bazel-out/ paths
-            if arg.contains("bazel-out/") {
-                let transformedArg = arg.replacingOccurrences(of: "bazel-out/", with: outputPath + "/")
-
-                compilerArguments.append(transformedArg)
-                index += 1
-                continue
-            }
-
-            // Transform external/ paths
-            if arg.contains("external/") {
-                let transformedArg = arg.replacingOccurrences(of: "external/", with: outputBase + "/external/")
-                compilerArguments.append(transformedArg)
-                index += 1
+            // For Swift, swap the index store arg with the global cache.
+            // Bazel handles this a bit differently internally, which is why
+            // we need to do this.
+            if arg == "-index-store-path" {
+                compilerArguments.append("-index-store-path")
+                compilerArguments.append(initializedConfig.indexStorePath)
+                index += 2
                 continue
             }
 
@@ -336,7 +278,7 @@ final class TextDocumentSourceKitOptionsHandler {
                 continue
             }
 
-            // Same thing for modulemaps.
+            // Same as above, but for modulemaps.
             if arg.hasPrefix("-fmodule-map-file="), !arg.hasPrefix("-fmodule-map-file=/") {
                 let components = arg.components(separatedBy: "-fmodule-map-file=")
                 let proper = rootUri + "/" + components[1]
@@ -346,8 +288,72 @@ final class TextDocumentSourceKitOptionsHandler {
                 continue
             }
 
+            // Otherwise, just add the argument.
             compilerArguments.append(arg)
             index += 1
+        }
+
+        // Now, replace Bazel env placeholders with the actual values
+        for i in 0 ..< compilerArguments.count {
+            let arg = compilerArguments[i]
+
+            if arg.contains(BazelEnvPlaceholder.execRoot.rawValue) {
+                compilerArguments[i] = arg.replacingOccurrences(
+                    of: BazelEnvPlaceholder.execRoot.rawValue,
+                    with: rootUri
+                )
+                continue
+            }
+
+            if arg.contains(BazelEnvPlaceholder.sdkRoot.rawValue) {
+                compilerArguments[i] = arg.replacingOccurrences(
+                    of: BazelEnvPlaceholder.sdkRoot.rawValue,
+                    with: sdkRoot
+                )
+                continue
+            }
+
+            if arg.contains(BazelEnvPlaceholder.devDir.rawValue) {
+                compilerArguments[i] = arg.replacingOccurrences(
+                    of: BazelEnvPlaceholder.devDir.rawValue,
+                    with: devDir
+                )
+                continue
+            }
+
+            // For bazel-out/, we want to replace the symlinks only,
+            // not references to the actual folder.
+            if arg.contains("bazel-out/") && !arg.contains("execroot/_main/bazel-out/") {
+                // FIXME: Need guardrails to make sure this is actually
+                // the bazel-out and not some path who just happens to have
+                // bazel-out/ in its name
+                compilerArguments[i] = arg.replacingOccurrences(
+                    of: "bazel-out/",
+                    with: outputPath + "/"
+                )
+                continue
+            }
+
+            if arg.contains("external/") {
+                // FIXME: Need guardrails to make sure this is actually
+                // the folder we're looking for and not some path who just happens to have
+                // external/ in its name
+                compilerArguments[i] = arg.replacingOccurrences(
+                    of: "external/",
+                    with: outputBase + "/external/"
+                )
+                continue
+            }
+        }
+
+        if indexingObjCHeader {
+            // For Obj-C, add additional arguments that are needed for indexing
+            // that Bazel / SK doesn't add by default, and adjust other inconsistencies
+            // with Xcode index builds.
+            compilerArguments.append("-index-store-path")
+            compilerArguments.append(initializedConfig.indexStorePath)
+            compilerArguments.append("-working-directory")
+            compilerArguments.append(initializedConfig.rootUri)
         }
 
         return compilerArguments


### PR DESCRIPTION
Moving things around so that most of the work is done in one run, and checking arguments more directly when we know exactly what we're looking for