### PR TITLE
Clean-up the BSPServer entrypoint code

### DIFF
--- a/Sources/SourceKitBazelBSP/LSPConnection.swift
+++ b/Sources/SourceKitBazelBSP/LSPConnection.swift
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+import LanguageServerProtocol
+import LanguageServerProtocolJSONRPC
+
+/// Extends the original sourcekit-lsp `Connection` type to include JSONRPCConnection's start method.
+package protocol LSPConnection: Connection {
+    func start(
+        receiveHandler: MessageHandler,
+        closeHandler: @escaping @Sendable () async -> Void
+    )
+}
+
+extension JSONRPCConnection: LSPConnection {}

--- a/Sources/SourceKitBazelBSP/Logger.swift
+++ b/Sources/SourceKitBazelBSP/Logger.swift
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+import OSLog
+
+/// Simple helper to create loggers under the `sourcekit-bazel-bsp` subsystem.
+package func makeBSPLogger(withCategory category: String) -> Logger {
+    Logger(subsystem: "sourcekit-bazel-bsp", category: category)
+}

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve/Serve.swift
@@ -26,9 +26,16 @@ struct Serve: ParsableCommand {
     @Option(help: "The name of the Bazel CLI to invoke (e.g. 'bazelisk')")
     var bazelWrapper: String = "bazel"
 
+    // FIXME: We should support any library target, not just the app ones.
+    // The problem is that ios_application targets apply transitions that don't get reflected
+    // when building libraries individually. Queries have a --universe_scope flag to account for this,
+    // but this is not available for build actions at the moment. We need to find a stable way of building
+    // libraries with the same configs that would be applied when building the full app.
     @Option(
         parsing: .singleValue,
-        help: "The Bazel ios_application or test targets that this should serve a BSP for.")
+        help:
+            "The Bazel ios_application or test targets that this should serve a BSP for. Can be specified multiple times."
+    )
     var target: [String]
 
     @Option(
@@ -53,7 +60,7 @@ struct Serve: ParsableCommand {
             indexFlags: indexFlag.map { "--" + $0 },
             filesToWatch: filesToWatch
         )
-        let server = BSPServer(baseConfig: config)
+        let server = SourceKitBazelBSPServer(baseConfig: config)
         try server.run()
     }
 }

--- a/Tests/SourceKitBazelBSPTests/Fakes/LSPConnectionFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/LSPConnectionFake.swift
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import LanguageServerProtocol
+import LanguageServerProtocolJSONRPC
+
+@testable import SourceKitBazelBSP
+
+final class LSPConnectionFake: LSPConnection {
+
+    nonisolated(unsafe) private(set) var startCalled = false
+    nonisolated(unsafe) private(set) var startReceivedHandler: MessageHandler?
+
+    func start(
+        receiveHandler: MessageHandler,
+        closeHandler: @escaping @Sendable () async -> Void
+    ) {
+        startCalled = true
+        startReceivedHandler = receiveHandler
+    }
+
+    func nextRequestID() -> LanguageServerProtocol.RequestID {
+        unimplemented()
+    }
+
+    func send(_ notification: some NotificationType) {
+        unimplemented()
+    }
+
+    func send<Request>(
+        _ request: Request, id: LanguageServerProtocol.RequestID,
+        reply: @escaping @Sendable (LanguageServerProtocol.LSPResult<Request.Response>) -> Void
+    ) where Request: LanguageServerProtocol.RequestType {
+        unimplemented()
+    }
+}

--- a/Tests/SourceKitBazelBSPTests/Fakes/MessageHandlerFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/MessageHandlerFake.swift
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import LanguageServerProtocol
+
+@testable import SourceKitBazelBSP
+
+final class MessageHandlerFake: MessageHandler {
+    func handle(_ notification: some NotificationType) {
+        preconditionFailure("Not implemented")
+    }
+
+    func handle<Request: RequestType>(
+        _ request: Request,
+        id: RequestID,
+        reply: @escaping (LSPResult<Request.Response>) -> Void
+    ) {
+        preconditionFailure("Not implemented")
+    }
+}

--- a/Tests/SourceKitBazelBSPTests/Fakes/SharedFakeUtils.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/SharedFakeUtils.swift
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+func unimplemented() -> Never {
+    preconditionFailure("Not implemented")
+}

--- a/Tests/SourceKitBazelBSPTests/SourceKitBazelBSPServerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/SourceKitBazelBSPServerTests.swift
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import LanguageServerProtocol
+import LanguageServerProtocolJSONRPC
+import Testing
+
+@testable import SourceKitBazelBSP
+
+@Suite struct SourceKitBazelBSPServerTests {
+    @Test
+    func runAttachesHandler() throws {
+        let mockConnection = LSPConnectionFake()
+        let mockHandler = MessageHandlerFake()
+
+        let server = SourceKitBazelBSPServer(
+            connection: mockConnection,
+            handler: mockHandler
+        )
+
+        try server.run(parkThread: false)
+
+        #expect(mockConnection.startCalled == true)
+        #expect(mockConnection.startReceivedHandler === mockHandler)
+    }
+}


### PR DESCRIPTION
First of a couple of PRs to refactor code and unit test everything.

- Renamed BSPServer -> SourceKitBazelBSPServer
- Re-structured the init code so that everything is behind more generic protocols
- Adding fakes for the protocols related to this class
- Added a simple unit test file for the start-related code