### PR TITLE
Refactor build target handling logic

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+enum BazelTargetQuerierError: Error, LocalizedError {
+    case noKinds
+    case noTargets
+
+    var errorDescription: String? {
+        switch self {
+        case .noKinds:
+            return "A list of kinds is necessary to query targets"
+        case .noTargets:
+            return "A list of targets is necessary to query targets"
+        }
+    }
+}
+
+/// Small abstraction to handle and cache the results of bazel queries.
+///
+/// FIXME: Currently uses XML, should use proto instead so that we can organize and test this properly
+final class BazelTargetQuerier {
+
+    private let commandRunner: CommandRunner
+    private var queryCache = [String: XMLElement]()
+
+    static func queryDepsString(forTargets targets: [String]) -> String {
+        var query = ""
+        for target in targets {
+            if query == "" {
+                query = "deps(\(target))"
+            } else {
+                query += " union deps(\(target))"
+            }
+        }
+        return query
+    }
+
+    init(commandRunner: CommandRunner = ShellCommandRunner()) {
+        self.commandRunner = commandRunner
+    }
+
+    func queryTargets(
+        forConfig config: BaseServerConfig,
+        rootUri: String,
+        kinds: Set<String>
+    ) throws
+        -> XMLElement
+    {
+        guard !kinds.isEmpty else {
+            throw BazelTargetQuerierError.noKinds
+        }
+
+        guard !config.targets.isEmpty else {
+            throw BazelTargetQuerierError.noTargets
+        }
+
+        let kindsFilter = kinds.sorted().joined(separator: "|")
+        let depsQuery = Self.queryDepsString(forTargets: config.targets)
+        let cacheKey = "\(kindsFilter)+\(depsQuery)"
+
+        logger.info("Processing query request for \(cacheKey, privacy: .public)")
+
+        if let cached = queryCache[cacheKey] {
+            logger.debug("Returning cached results")
+            return cached
+        }
+
+        // We run this one on the main output base since it's not related to the actual indexing bits
+        let cmd = "query \"kind('\(kindsFilter)', \(depsQuery))\" --output xml"
+        let output = try commandRunner.bazel(
+            baseConfig: config,
+            rootUri: rootUri,
+            cmd: cmd
+        )
+
+        logger.debug("Finished querying, building result XML")
+
+        guard let xml = try XMLDocument(xmlString: output).rootElement() else {
+            throw WorkspaceBuildTargetsError.invalidQueryOutput
+        }
+
+        queryCache[cacheKey] = xml
+
+        return xml
+    }
+
+    func clearCache() {
+        queryCache = [:]
+    }
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -1,0 +1,117 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import Foundation
+import LanguageServerProtocol
+
+enum BazelTargetStoreError: Error, LocalizedError {
+    case unknownBSPURI(URI)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownBSPURI(let uri):
+            return "Requested data about a URI, but couldn't find it in the store: \(uri)"
+        }
+    }
+}
+
+/// Abstraction that can queries, processes, and stores the project's dependency graph and its files.
+/// Used by many of the requests to calculate and provide data about the project's targets.
+final class BazelTargetStore {
+
+    // The list of rules we currently care about and can process
+    static let supportedRuleTypes: Set<String> = [
+        "swift_library",
+        "objc_library",
+    ]
+
+    private let initializedConfig: InitializedServerConfig
+    private let bazelTargetQuerier: BazelTargetQuerier
+
+    private var bspURIsToBazelLabelsMap: [URI: String] = [:]
+    private var bspURIsToSrcsMap: [URI: [URI]] = [:]
+    private var srcToBspURIsMap: [URI: [URI]] = [:]
+
+    init(
+        initializedConfig: InitializedServerConfig,
+        bazelTargetQuerier: BazelTargetQuerier = BazelTargetQuerier()
+    ) {
+        self.initializedConfig = initializedConfig
+        self.bazelTargetQuerier = bazelTargetQuerier
+    }
+
+    /// Converts a BSP BuildTarget URI to its underlying Bazel target label.
+    func bazelTargetLabel(forBSPURI uri: URI) throws -> String {
+        guard let label = bspURIsToBazelLabelsMap[uri] else {
+            throw BazelTargetStoreError.unknownBSPURI(uri)
+        }
+        return label
+    }
+
+    /// Retrieves the list of registered source files for a given a BSP BuildTarget URI.
+    func bazelTargetSrcs(forBSPURI uri: URI) throws -> [URI] {
+        guard let srcs = bspURIsToSrcsMap[uri] else {
+            throw BazelTargetStoreError.unknownBSPURI(uri)
+        }
+        return srcs
+    }
+
+    /// Retrieves the list of BSP BuildTarget URIs that contain a given source file.
+    func bspURIs(containingSrc src: URI) throws -> [URI] {
+        guard let bspURIs = srcToBspURIsMap[src] else {
+            throw BazelTargetStoreError.unknownBSPURI(src)
+        }
+        return bspURIs
+    }
+
+    func fetchTargets() throws -> [BuildTarget] {
+        let xml = try bazelTargetQuerier.queryTargets(
+            forConfig: initializedConfig.baseConfig,
+            rootUri: initializedConfig.rootUri,
+            kinds: Self.supportedRuleTypes
+        )
+
+        let targetData = try BazelQueryParser.parseTargets(
+            from: xml,
+            supportedRuleTypes: Self.supportedRuleTypes,
+            rootUri: initializedConfig.rootUri,
+            toolchainPath: initializedConfig.devToolchainPath
+        )
+
+        // Fill the local cache based on the data we got from the query
+        for (target, srcs) in targetData {
+            let uri = target.id.uri
+            bspURIsToBazelLabelsMap[uri] = target.displayName
+            bspURIsToSrcsMap[uri] = srcs
+            for src in srcs {
+                srcToBspURIsMap[src, default: []].append(uri)
+            }
+        }
+
+        return targetData.map { $0.0 }
+    }
+
+    func clearCache() {
+        bspURIsToBazelLabelsMap = [:]
+        bspURIsToSrcsMap = [:]
+        srcToBspURIsMap = [:]
+        bazelTargetQuerier.clearCache()
+    }
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BuildTargetsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BuildTargetsHandler.swift
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import Foundation
+import LanguageServerProtocol
+
+/// Handles the `workspace/buildTargets` request.
+///
+/// Processes the project's dependency graph and returns it to the LSP.
+final class BuildTargetsHandler {
+
+    private let targetStore: BazelTargetStore
+    private weak var connection: LSPConnection?
+
+    init(
+        targetStore: BazelTargetStore,
+        connection: LSPConnection? = nil,
+    ) {
+        self.targetStore = targetStore
+        self.connection = connection
+    }
+
+    func workspaceBuildTargets(
+        _ request: WorkspaceBuildTargetsRequest,
+        _ id: RequestID
+    ) throws -> WorkspaceBuildTargetsResponse {
+        let taskId = TaskId(id: "buildTargets-\(id.description)")
+        connection?.startWorkTask(
+            id: taskId,
+            title: "Indexing: Processing build graph"
+        )
+        do {
+            let result = try targetStore.fetchTargets()
+            logger.debug("Found \(result.count, privacy: .public) targets")
+            connection?.finishTask(id: taskId, status: .ok)
+            return WorkspaceBuildTargetsResponse(targets: result)
+        } catch {
+            connection?.finishTask(id: taskId, status: .error)
+            throw error
+        }
+    }
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/_old/TextDocumentSourceKitOptionsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/_old/TextDocumentSourceKitOptionsHandler.swift
@@ -84,7 +84,8 @@ final class TextDocumentSourceKitOptionsHandler {
         }
         logger.info("Getting compiler arguments for \(cacheKey, privacy: .public)")
         let bazelWrapper = initializedConfig.baseConfig.bazelWrapper
-        let appToBuild = initializedConfig.baseConfig.aqueryString
+        let appToBuild = BazelTargetQuerier.queryDepsString(
+            forTargets: initializedConfig.baseConfig.targets)
         let outputBase = initializedConfig.outputBase
         let rootUri = initializedConfig.rootUri
         let flags = initializedConfig.baseConfig.indexFlags.joined(separator: " ")

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -41,16 +41,4 @@ package struct BaseServerConfig: Equatable {
         self.indexFlags = indexFlags
         self.filesToWatch = filesToWatch
     }
-
-    var aqueryString: String {
-        var query = ""
-        for target in self.targets {
-            if query == "" {
-                query = "deps(\(target))"
-            } else {
-                query += " union deps(\(target))"
-            }
-        }
-        return query
-    }
 }

--- a/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
@@ -28,6 +28,7 @@ struct InitializedServerConfig: Equatable {
     let outputPath: String
     let devDir: String
     let sdkRoot: String
+    let devToolchainPath: String
 
     var indexDatabasePath: String {
         outputPath + "/_global_index_database"

--- a/Sources/SourceKitBazelBSP/Server/MessageHandler/BSPServerMessageHandlerImpl.swift
+++ b/Sources/SourceKitBazelBSP/Server/MessageHandler/BSPServerMessageHandlerImpl.swift
@@ -95,7 +95,8 @@ final class BSPServerMessageHandlerImpl: @unchecked Sendable {
                 outputBase: outputBase,
                 outputPath: outputPath,
                 devDir: devDir,
-                sdkRoot: sdkRoot
+                sdkRoot: sdkRoot,
+                devToolchainPath: devDir + "/Toolchains/XcodeDefault.xctoolchain/"
             )
             let result = try InitializeRequestHandler().handle(
                 request: request,

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -1,0 +1,150 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+import Testing
+
+@testable import SourceKitBazelBSP
+
+@Suite struct BazelTargetQuerierTests {
+
+    @Test
+    func executesCorrectBazelCommand() throws {
+        let runnerMock = CommandRunnerFake()
+        let querier = BazelTargetQuerier(commandRunner: runnerMock)
+
+        let config = BaseServerConfig(
+            bazelWrapper: "bazelisk",
+            targets: ["//HelloWorld"],
+            indexFlags: ["--config=test"],
+            filesToWatch: nil
+        )
+
+        let expectedCommand =
+            "bazelisk query \"kind('swift_library', deps(//HelloWorld))\" --output xml"
+        runnerMock.setResponse(
+            for: expectedCommand,
+            response: mockXml
+        )
+
+        let kinds: Set<String> = ["swift_library"]
+        let result = try querier.queryTargets(
+            forConfig: config,
+            rootUri: "/path/to/project",
+            kinds: kinds
+        )
+
+        let ranCommands = runnerMock.commands
+        #expect(ranCommands.count == 1)
+        #expect(ranCommands[0].command == expectedCommand)
+        #expect(ranCommands[0].cwd == "/path/to/project")
+        #expect(result.children?.count == 2)
+    }
+
+    @Test
+    func queryingMultipleKindsAndTargets() throws {
+        let runnerMock = CommandRunnerFake()
+        let querier = BazelTargetQuerier(commandRunner: runnerMock)
+
+        let config = BaseServerConfig(
+            bazelWrapper: "bazelisk",
+            targets: ["//HelloWorld", "//Tests"],
+            indexFlags: ["--config=test"],
+            filesToWatch: nil
+        )
+
+        let expectedCommand =
+            "bazelisk query \"kind('objc_library|swift_library', deps(//HelloWorld) union deps(//Tests))\" --output xml"
+        runnerMock.setResponse(
+            for: expectedCommand,
+            response: mockXml
+        )
+
+        let kinds: Set<String> = ["swift_library", "objc_library"]
+        let result = try querier.queryTargets(
+            forConfig: config,
+            rootUri: "/path/to/project",
+            kinds: kinds
+        )
+
+        let ranCommands = runnerMock.commands
+        #expect(ranCommands.count == 1)
+        #expect(ranCommands[0].command == expectedCommand)
+        #expect(ranCommands[0].cwd == "/path/to/project")
+        #expect(result.children?.count == 2)
+    }
+
+    @Test
+    func cachesQueryResults() throws {
+        let runnerMock = CommandRunnerFake()
+        let querier = BazelTargetQuerier(commandRunner: runnerMock)
+
+        let config = BaseServerConfig(
+            bazelWrapper: "bazel",
+            targets: ["//HelloWorld"],
+            indexFlags: [],
+            filesToWatch: nil
+        )
+
+        func run(_ kinds: Set<String>) throws {
+            _ = try querier.queryTargets(
+                forConfig: config,
+                rootUri: "/path/to/project",
+                kinds: kinds
+            )
+        }
+
+        var kinds: Set<String> = ["swift_library"]
+
+        runnerMock.setResponse(
+            for: "bazel query \"kind('swift_library', deps(//HelloWorld))\" --output xml",
+            response: mockXml
+        )
+        runnerMock.setResponse(
+            for: "bazel query \"kind('objc_library', deps(//HelloWorld))\" --output xml",
+            response: mockXml
+        )
+
+        try run(kinds)
+        try run(kinds)
+
+        #expect(runnerMock.commands.count == 1)
+
+        // Querying something else then results in a new command
+        kinds = ["objc_library"]
+        try run(kinds)
+        #expect(runnerMock.commands.count == 2)
+        try run(kinds)
+        #expect(runnerMock.commands.count == 2)
+
+        // But the original call is still cached
+        kinds = ["swift_library"]
+        try run(kinds)
+        #expect(runnerMock.commands.count == 2)
+    }
+}
+
+private let mockXml = """
+    <?xml version="1.1" encoding="UTF-8" standalone="no"?>
+    <query version="2">
+        <rule class="swift_library" name="//HelloWorld:lib1" />
+        <rule class="swift_library" name="//HelloWorld:lib2" />
+    </query>
+
+    """

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -29,7 +29,6 @@ import Testing
     @Test
     func makeConfigGathersCorrectInformation() throws {
         let commandRunner = CommandRunnerFake()
-        let connection = LSPConnectionFake()
         let baseConfig = BaseServerConfig(
             bazelWrapper: "mybazel",
             targets: ["//HelloWorld"],
@@ -41,6 +40,7 @@ import Testing
         let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/exec"
         let devDir = "/Applications/Xcode.app/Contents/Developer"
         let sdkRoot = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimu.sdk"
+        let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
         commandRunner.setResponse(for: "mybazel info output_base", response: outputBase)
         commandRunner.setResponse(
@@ -51,11 +51,11 @@ import Testing
         commandRunner.setResponse(for: "xcode-select --print-path", response: devDir)
         commandRunner.setResponse(
             for: "xcrun --sdk iphonesimulator --show-sdk-path", response: sdkRoot)
+        commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
 
         let handler = InitializeHandler(
             baseConfig: baseConfig,
-            commandRunner: commandRunner,
-            connection: connection
+            commandRunner: commandRunner
         )
 
         let rootUri = "file:///path/to/project"
@@ -74,14 +74,14 @@ import Testing
                     outputBase: outputBase + "-sourcekit-bazel-bsp",
                     outputPath: outputPath,
                     devDir: devDir,
-                    sdkRoot: sdkRoot
+                    sdkRoot: sdkRoot,
+                    devToolchainPath: toolchain
                 ))
     }
 
     @Test
     func makeConfigWithNoIndexFlags() throws {
         let commandRunner = CommandRunnerFake()
-        let connection = LSPConnectionFake()
         let baseConfig = BaseServerConfig(
             bazelWrapper: "mybazel",
             targets: ["//HelloWorld"],
@@ -91,6 +91,7 @@ import Testing
 
         let outputBase = "/_bazel_user/abc123"
         let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/exec"
+        let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
         commandRunner.setResponse(for: "mybazel info output_base", response: outputBase)
         commandRunner.setResponse(
@@ -98,11 +99,11 @@ import Testing
                 "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info output_path",
             response: outputPath
         )
+        commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
 
         let handler = InitializeHandler(
             baseConfig: baseConfig,
-            commandRunner: commandRunner,
-            connection: connection
+            commandRunner: commandRunner
         )
 
         let rootUri = "file:///path/to/project"
@@ -119,7 +120,6 @@ import Testing
     @Test
     func makeConfigWithMultipleIndexFlags() throws {
         let commandRunner = CommandRunnerFake()
-        let connection = LSPConnectionFake()
         let baseConfig = BaseServerConfig(
             bazelWrapper: "mybazel",
             targets: ["//HelloWorld"],
@@ -129,6 +129,7 @@ import Testing
 
         let outputBase = "/_bazel_user/abc123"
         let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/exec"
+        let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
         commandRunner.setResponse(for: "mybazel info output_base", response: outputBase)
         commandRunner.setResponse(
@@ -136,11 +137,11 @@ import Testing
                 "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info output_path --config=index1 --config=index2",
             response: outputPath
         )
+        commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
 
         let handler = InitializeHandler(
             baseConfig: baseConfig,
-            commandRunner: commandRunner,
-            connection: connection
+            commandRunner: commandRunner
         )
 
         let rootUri = "file:///path/to/project"


### PR DESCRIPTION
Similar to https://github.com/spotify/sourcekit-bazel-bsp/pull/15, but this time targeting the dependency graph gathering logic.

A lot of the parsing logic itself is WIP, but I wanted to get the structure correct first.