### PR TITLE
Add LockIsolated For Recursive Registration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,10 @@ let package = Package(
             name: "BazelProtobufBindings",
             dependencies: [
                 .product(name: "SwiftProtobuf", package: "swift-protobuf")
+            ],
+            exclude: [
+                "README.md",
+                "analysis_v2.proto",
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Refactor BSPMessageHandler to use LockIsolated for state management and add recursive registration test
     - fix the build error in Package.swift
    - use NSRecursiveLock to fix the nonisolated state