### PR TITLE
Add exclude list for BazelProtobufBindings target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,10 @@ let package = Package(
             name: "BazelProtobufBindings",
             dependencies: [
                 .product(name: "SwiftProtobuf", package: "swift-protobuf")
+            ],
+            exclude: [
+                "README.md",
+                "analysis_v2.proto",
             ]
         ),
         .testTarget(


### PR DESCRIPTION
When building with `swift build` the warning suggest to put **README.md** and **analysis_v2.proto** in the exclude list