### PR TITLE
Dynamically query for build targets

### DIFF
--- a/Sources/SourceKitBazelBSP/TargetDiscovery/DiscoverTargets.swift
+++ b/Sources/SourceKitBazelBSP/TargetDiscovery/DiscoverTargets.swift
@@ -57,7 +57,8 @@ func discoverTargetsInternal(
 
     let output = try commandRunner.run(cmd)
 
-    let discoveredTargets = output
+    let discoveredTargets =
+        output
         .trimmingCharacters(in: .whitespacesAndNewlines)
         .components(separatedBy: .newlines)
         .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }

--- a/Sources/SourceKitBazelBSP/TargetDiscovery/DiscoverTargets.swift
+++ b/Sources/SourceKitBazelBSP/TargetDiscovery/DiscoverTargets.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+// MARK: - Logger
+
+private let logger = makeFileLevelBSPLogger()
+
+// MARK: - Public API
+
+public enum TopLevelTarget: String {
+    case iosApplication = "ios_application"
+    case iosUnitTest = "ios_unit_test"
+}
+
+public enum DiscoverTargetsError: LocalizedError, Equatable {
+    case noTargetsDiscovered
+
+    public var errorDescription: String? {
+        switch self {
+        case .noTargetsDiscovered: return "No targets discovered!"
+        }
+    }
+}
+
+/// Discovers Bazel targets matching the specified rule types by running a Bazel query.
+///
+/// - Parameters:
+///   - rules: The rule types to search for (e.g. ios_application, ios_unit_test)
+///   - bazelWrapper: The Bazel executable to use (defaults to "bazel")
+/// - Returns: An array of discovered target labels
+/// - Throws: DiscoverTargetsError.noTargetsDiscovered if no matching targets are found
+public func discoverTargets(
+    for rules: TopLevelTarget...,
+    bazelWrapper: String = "bazel"
+) throws -> [String] {
+    try discoverTargetsInternal(
+        for: rules,
+        bazelWrapper: bazelWrapper,
+        commandRunner: ShellCommandRunner()
+    )
+}
+
+// MARK: - Internal API
+
+func discoverTargetsInternal(
+    for rules: [TopLevelTarget],
+    bazelWrapper: String = "bazel",
+    commandRunner: CommandRunner
+) throws -> [String] {
+    logger.info("Discovering targets for rules: \(rules.map { $0.rawValue }.joined(separator: ", "))")
+
+    let query = rules.map {
+        "kind(\($0.rawValue), ...)"
+    }
+    .joined(separator: " + ")
+
+    let cmd = "\(bazelWrapper) query '\(query)' --output label"
+
+    let output = try commandRunner.run(cmd)
+
+    let discoveredTargets = output
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .components(separatedBy: .newlines)
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+
+    if discoveredTargets.isEmpty {
+        logger.error("No targets discovered!")
+        throw DiscoverTargetsError.noTargetsDiscovered
+    }
+
+    return discoveredTargets
+}

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -31,20 +31,20 @@ struct Serve: ParsableCommand {
     @Option(
         parsing: .singleValue,
         help:
-        "The *top level* Bazel application or test targets that this should serve a BSP for. Can be specified multiple times. If not specified, the server will try to discover top-leveltargets automatically."
+            "The *top level* Bazel application or test targets that this should serve a BSP for. Can be specified multiple times. If not specified, the server will try to discover top-leveltargets automatically."
     )
     var target: [String] = []
 
     @Option(
         parsing: .singleValue,
         help:
-        "A flag that should be passed to all indexing-related Bazel invocations. Do not include the -- prefix. Can be specified multiple times."
+            "A flag that should be passed to all indexing-related Bazel invocations. Do not include the -- prefix. Can be specified multiple times."
     )
     var indexFlag: [String] = []
 
     @Option(
         help:
-        "The expected suffix for build_test targets. Defaults to '_skbsp'."
+            "The expected suffix for build_test targets. Defaults to '_skbsp'."
     )
     var buildTestSuffix: String = "_skbsp"
 

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -31,20 +31,20 @@ struct Serve: ParsableCommand {
     @Option(
         parsing: .singleValue,
         help:
-            "The *top level* Bazel application or test targets that this should serve a BSP for. Can be specified multiple times."
+        "The *top level* Bazel application or test targets that this should serve a BSP for. Can be specified multiple times. If not specified, the server will try to discover top-leveltargets automatically."
     )
-    var target: [String]
+    var target: [String] = []
 
     @Option(
         parsing: .singleValue,
         help:
-            "A flag that should be passed to all indexing-related Bazel invocations. Do not include the -- prefix. Can be specified multiple times."
+        "A flag that should be passed to all indexing-related Bazel invocations. Do not include the -- prefix. Can be specified multiple times."
     )
     var indexFlag: [String] = []
 
     @Option(
         help:
-            "The expected suffix for build_test targets. Defaults to '_skbsp'."
+        "The expected suffix for build_test targets. Defaults to '_skbsp'."
     )
     var buildTestSuffix: String = "_skbsp"
 
@@ -53,9 +53,17 @@ struct Serve: ParsableCommand {
 
     func run() throws {
         logger.info("`serve` invoked, initializing BSP server...")
+
+        let targets = try {
+            if !target.isEmpty {
+                return target
+            }
+            return try discoverTargets(for: .iosApplication, .iosUnitTest, bazelWrapper: bazelWrapper)
+        }()
+
         let config = BaseServerConfig(
             bazelWrapper: bazelWrapper,
-            targets: target,
+            targets: targets,
             indexFlags: indexFlag.map { "--" + $0 },
             buildTestSuffix: buildTestSuffix,
             filesToWatch: filesToWatch

--- a/Tests/SourceKitBazelBSPTests/DiscoverTargetsTests.swift
+++ b/Tests/SourceKitBazelBSPTests/DiscoverTargetsTests.swift
@@ -58,7 +58,10 @@ struct DiscoverTargetsTests {
 
         #expect(targets == ["//Example/HelloWorld:HelloWorld", "//Example/HelloWorldTests:HelloWorldTests"])
         #expect(commandRunner.commands.count == 1)
-        #expect(commandRunner.commands[0].command == "bazel query 'kind(ios_application, ...) + kind(ios_unit_test, ...)' --output label")
+        #expect(
+            commandRunner.commands[0].command
+                == "bazel query 'kind(ios_application, ...) + kind(ios_unit_test, ...)' --output label"
+        )
     }
 
     @Test("Throws error when no targets found")

--- a/Tests/SourceKitBazelBSPTests/DiscoverTargetsTests.swift
+++ b/Tests/SourceKitBazelBSPTests/DiscoverTargetsTests.swift
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+import Testing
+
+@testable import SourceKitBazelBSP
+
+struct DiscoverTargetsTests {
+    @Test("Discovers single rule type with multiple targets")
+    func discoverSingleRuleTypeWithMultipleTargets() throws {
+        let commandRunner = CommandRunnerFake()
+        commandRunner.setResponse(
+            for: "bazel query 'kind(ios_application, ...)' --output label",
+            response: "//Example/HelloWorld:HelloWorld\n//Example/AnotherApp:AnotherApp\n"
+        )
+
+        let targets = try discoverTargetsInternal(
+            for: [.iosApplication],
+            bazelWrapper: "bazel",
+            commandRunner: commandRunner
+        )
+
+        #expect(targets == ["//Example/HelloWorld:HelloWorld", "//Example/AnotherApp:AnotherApp"])
+        #expect(commandRunner.commands.count == 1)
+        #expect(commandRunner.commands[0].command == "bazel query 'kind(ios_application, ...)' --output label")
+    }
+
+    @Test("Discovers multiple rule types")
+    func discoverMultipleRuleTypes() throws {
+        let commandRunner = CommandRunnerFake()
+        commandRunner.setResponse(
+            for: "bazel query 'kind(ios_application, ...) + kind(ios_unit_test, ...)' --output label",
+            response: "//Example/HelloWorld:HelloWorld\n//Example/HelloWorldTests:HelloWorldTests\n"
+        )
+
+        let targets = try discoverTargetsInternal(
+            for: [.iosApplication, .iosUnitTest],
+            bazelWrapper: "bazel",
+            commandRunner: commandRunner
+        )
+
+        #expect(targets == ["//Example/HelloWorld:HelloWorld", "//Example/HelloWorldTests:HelloWorldTests"])
+        #expect(commandRunner.commands.count == 1)
+        #expect(commandRunner.commands[0].command == "bazel query 'kind(ios_application, ...) + kind(ios_unit_test, ...)' --output label")
+    }
+
+    @Test("Throws error when no targets found")
+    func throwsErrorWhenNoTargetsFound() throws {
+        let commandRunner = CommandRunnerFake()
+        commandRunner.setResponse(
+            for: "bazel query 'kind(ios_application, ...)' --output label",
+            response: "\n  \n"
+        )
+
+        #expect(throws: DiscoverTargetsError.noTargetsDiscovered) {
+            try discoverTargetsInternal(
+                for: [.iosApplication],
+                bazelWrapper: "bazel",
+                commandRunner: commandRunner
+            )
+        }
+    }
+}


### PR DESCRIPTION
If `--target` flag(s) aren't specified, we will now perform a bazel query using `bazel query 'kind(ios_unit_test, ...) + kind(ios_application, ...)'` to fetch all the targets in the project.