### PR TITLE
Add support for building libraries individually

### DIFF
--- a/Example/HelloWorld/BUILD
+++ b/Example/HelloWorld/BUILD
@@ -1,9 +1,11 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test", "ios_build_test")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_interop_hint")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_interop_hint")
 load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template_rule")
+load("//tools:apple.bzl", "hello_objc_library", "hello_swift_library", "IOS_MINIMUM_OS_VERSION")
 
+## MARK: Libraries
 
-swift_library(
+hello_swift_library(
     name = "HelloWorldTestsLib",
     module_name = "HelloWorldTestsLib",
     testonly = True,
@@ -12,26 +14,10 @@ swift_library(
     deps = [":HelloWorldLib"],
 )
 
-ios_build_test(
-    name = "HelloWorldTestsLib_skbsp_ios",
-    minimum_os_version = "17.0",
-    targets = [
-        ":HelloWorldTestsLib",
-    ],
-)
-
-swift_library(
+hello_swift_library(
     name = "TodoModels",
     module_name = "TodoModels",
     srcs = glob(["TodoModels/Sources/*.swift"]),
-)
-
-ios_build_test(
-    name = "TodoModels_skbsp_ios",
-    minimum_os_version = "17.0",
-    targets = [
-        ":TodoModels",
-    ],
 )
 
 swift_interop_hint(
@@ -40,7 +26,7 @@ swift_interop_hint(
     module_map = "TodoObjCSupport/Sources/module.modulemap",
 )
 
-objc_library(
+hello_objc_library(
     name = "TodoObjCSupport",
     srcs = glob(
         [
@@ -52,12 +38,11 @@ objc_library(
     aspect_hints = [":TodoObjCSupport_hint"],
 )
 
-ios_build_test(
-    name = "TodoObjCSupport_skbsp_ios",
-    minimum_os_version = "17.0",
-    targets = [
-        ":TodoObjCSupport",
-    ],
+hello_swift_library(
+    name = "HelloWorldLib",
+    module_name = "HelloWorldLib",
+    srcs = glob(["HelloWorldLib/Sources/*.swift"]),
+    deps = [":TodoModels", ":TodoObjCSupport", ":GeneratedDummy", ":ExpandedTemplate"],
 )
 
 genrule(
@@ -72,7 +57,7 @@ import Foundation
 
 struct GeneratedDummy {
     static let message = "Hello from generated Swift file!"
-    
+
     static func greet() -> String {
         return message
     }
@@ -81,58 +66,10 @@ EOF
 """,
 )
 
-swift_library(
+hello_swift_library(
     name = "GeneratedDummy",
     module_name = "GeneratedDummy",
     srcs = [":GenerateDummySwiftFile"],
-)
-
-ios_build_test(
-    name = "GeneratedDummy_skbsp_ios",
-    minimum_os_version = "17.0",
-    targets = [
-        ":GeneratedDummy",
-    ],
-)
-
-swift_library(
-    name = "HelloWorldLib",
-    module_name = "HelloWorldLib",
-    srcs = glob(["HelloWorldLib/Sources/*.swift"]),
-    deps = [":TodoModels", ":TodoObjCSupport", ":GeneratedDummy", ":ExpandedTemplate"],
-)
-
-ios_build_test(
-    name = "HelloWorldLib_skbsp_ios",
-    minimum_os_version = "17.0",
-    targets = [
-        ":HelloWorldLib",
-    ],
-)
-
-genrule(
-    name = "CreateTestCoverageManifest",
-    srcs = ["Sources/BazelApp.swift"],
-    outs = [
-        "CoverageManifest.instrumented_files",
-    ],
-    cmd = "echo $(SRCS) > $@",
-)
-
-ios_unit_test(
-    name = "HelloWorldTests",
-    minimum_os_version = "17.0",
-    test_coverage_manifest = "CoverageManifest.instrumented_files",
-    deps = [":HelloWorldTestsLib"],
-)
-
-ios_application(
-    name = "HelloWorld",
-    bundle_id = "com.example.HelloWorld",
-    families = ["iphone", "ipad"],
-    infoplists = ["Resources/Info.plist"],
-    minimum_os_version = "17.0",
-    deps = [":HelloWorldLib", ":GeneratedDummy"],
 )
 
 expand_template_rule(
@@ -145,17 +82,25 @@ expand_template_rule(
     },
 )
 
-swift_library(
+hello_swift_library(
     name = "ExpandedTemplate",
-    module_name = "ExpandedTemplate", 
+    module_name = "ExpandedTemplate",
     srcs = [":ExpandTemplateSwiftFile"],
 )
 
-ios_build_test(
-    name = "ExpandedTemplate_skbsp_ios",
-    minimum_os_version = "17.0",
-    targets = [
-        ":ExpandedTemplate",
-    ],
+## MARK: Top level targets
+
+ios_unit_test(
+    name = "HelloWorldTests",
+    minimum_os_version = IOS_MINIMUM_OS_VERSION,
+    deps = [":HelloWorldTestsLib"],
 )
 
+ios_application(
+    name = "HelloWorld",
+    bundle_id = "com.example.HelloWorld",
+    families = ["iphone", "ipad"],
+    infoplists = ["Resources/Info.plist"],
+    minimum_os_version = IOS_MINIMUM_OS_VERSION,
+    deps = [":HelloWorldLib", ":GeneratedDummy"],
+)

--- a/Example/HelloWorld/BUILD
+++ b/Example/HelloWorld/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test", "ios_build_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_interop_hint")
 load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template_rule")
 load("//tools:apple.bzl", "hello_objc_library", "hello_swift_library", "IOS_MINIMUM_OS_VERSION")

--- a/Example/HelloWorld/BUILD
+++ b/Example/HelloWorld/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test", "ios_build_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_interop_hint")
 load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template_rule")
 
@@ -12,10 +12,26 @@ swift_library(
     deps = [":HelloWorldLib"],
 )
 
+ios_build_test(
+    name = "HelloWorldTestsLib_skbsp_ios",
+    minimum_os_version = "17.0",
+    targets = [
+        ":HelloWorldTestsLib",
+    ],
+)
+
 swift_library(
     name = "TodoModels",
     module_name = "TodoModels",
     srcs = glob(["TodoModels/Sources/*.swift"]),
+)
+
+ios_build_test(
+    name = "TodoModels_skbsp_ios",
+    minimum_os_version = "17.0",
+    targets = [
+        ":TodoModels",
+    ],
 )
 
 swift_interop_hint(
@@ -34,6 +50,14 @@ objc_library(
     ),
     hdrs = glob(["TodoObjCSupport/Sources/*.h"]),
     aspect_hints = [":TodoObjCSupport_hint"],
+)
+
+ios_build_test(
+    name = "TodoObjCSupport_skbsp_ios",
+    minimum_os_version = "17.0",
+    targets = [
+        ":TodoObjCSupport",
+    ],
 )
 
 genrule(
@@ -63,11 +87,27 @@ swift_library(
     srcs = [":GenerateDummySwiftFile"],
 )
 
+ios_build_test(
+    name = "GeneratedDummy_skbsp_ios",
+    minimum_os_version = "17.0",
+    targets = [
+        ":GeneratedDummy",
+    ],
+)
+
 swift_library(
     name = "HelloWorldLib",
     module_name = "HelloWorldLib",
     srcs = glob(["HelloWorldLib/Sources/*.swift"]),
     deps = [":TodoModels", ":TodoObjCSupport", ":GeneratedDummy", ":ExpandedTemplate"],
+)
+
+ios_build_test(
+    name = "HelloWorldLib_skbsp_ios",
+    minimum_os_version = "17.0",
+    targets = [
+        ":HelloWorldLib",
+    ],
 )
 
 genrule(
@@ -109,5 +149,13 @@ swift_library(
     name = "ExpandedTemplate",
     module_name = "ExpandedTemplate", 
     srcs = [":ExpandTemplateSwiftFile"],
+)
+
+ios_build_test(
+    name = "ExpandedTemplate_skbsp_ios",
+    minimum_os_version = "17.0",
+    targets = [
+        ":ExpandedTemplate",
+    ],
 )
 

--- a/Example/tools/apple.bzl
+++ b/Example/tools/apple.bzl
@@ -12,7 +12,7 @@ def hello_swift_library(
         **kwargs,
     )
     ios_build_test(
-        name = name + "_skbsp_ios",
+        name = name + "_ios_skbsp",
         minimum_os_version = IOS_MINIMUM_OS_VERSION,
         targets = [
             name,
@@ -29,7 +29,7 @@ def hello_objc_library(
         **kwargs,
     )
     ios_build_test(
-        name = name + "_skbsp_ios",
+        name = name + "_ios_skbsp",
         minimum_os_version = IOS_MINIMUM_OS_VERSION,
         targets = [
             name,

--- a/Example/tools/apple.bzl
+++ b/Example/tools/apple.bzl
@@ -1,0 +1,37 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_build_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+IOS_MINIMUM_OS_VERSION = "17.0"
+
+def hello_swift_library(
+    name,
+    **kwargs,
+):
+    swift_library(
+        name = name,
+        **kwargs,
+    )
+    ios_build_test(
+        name = name + "_skbsp_ios",
+        minimum_os_version = IOS_MINIMUM_OS_VERSION,
+        targets = [
+            name,
+        ],
+    )
+
+
+def hello_objc_library(
+    name,
+    **kwargs,
+):
+    native.objc_library(
+        name = name,
+        **kwargs,
+    )
+    ios_build_test(
+        name = name + "_skbsp_ios",
+        minimum_os_version = IOS_MINIMUM_OS_VERSION,
+        targets = [
+            name,
+        ],
+    )

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/sourcekit-lsp",
-            revision: "12da8e5f54809b642701dd0dd6e145d3e0c67bc4"
+            revision: "5df8f3d9ac0e647238ed4203e8f399ae5a095aa3"
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
 
 - Make sure your Bazel project is using compatible versions of all iOS-related Bazel rulesets and is configured to generate Swift/Obj-C indexing data and debug symbols, either by default or under a specific config.
   - Detailed information on this is currently WIP, but you can currently check out the [example project](./Example) for an example.
+- Make sure all transitive libraries you'd like to use the BSP for have accompanying `(platform)_build_test` rules that directly targets them and are named `(lib_name)_ios_skbsp`. Only iOS rules are supported as of writing.
+  - This is because Bazel is currently missing a couple of important features we need in order to make this work in a clean way. This requirement can thus be seen as temporary, and you can expect it to be removed in the future as we evolve the tool and those missing features are introduced.
 - Download and install [the official Swift extension](https://marketplace.visualstudio.com/items?itemName=swiftlang.swift-vscode) for Cursor / VSCode.
 - Copy the .bsp/ folder on this repository to the root of the repository you'd like to use this tool for.
 - Edit the `argv` fields in `.bsp/config.json` to match the details for your app / setup. You can see all available options by running `sourcekit-bazel-bsp serve --help`.

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelQueryParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelQueryParser.swift
@@ -65,7 +65,6 @@ enum BazelQueryParser {
         let uriRaw = bazelTargetToURI(fullPath)
         let basePath = uriRaw.components(separatedBy: "___")[0]
         var targetSrcs: [URI] = []
-        let uri: URI = try URI(string: uriRaw)
 
         for child in (childElement.children ?? []) {
             if child.name != "list" { continue }
@@ -109,10 +108,14 @@ enum BazelQueryParser {
             capabilities.canTest = true
             tags.append(.test)
         }
+        // FIXME: This is assuming everything is iOS code. Will soon update this to handle all platforms.
+        let buildTestSuffix = "_ios_skbsp"
+        let uri: URI = try URI(string: uriRaw + buildTestSuffix)
+        let displayName = bazelTarget + buildTestSuffix
         return (
             BuildTarget(
                 id: BuildTargetIdentifier(uri: uri),
-                displayName: bazelTarget,
+                displayName: displayName,
                 baseDirectory: try URI(string: basePath),
                 tags: tags,
                 capabilities: capabilities,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelQueryParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelQueryParser.swift
@@ -28,7 +28,8 @@ enum BazelQueryParser {
         from xml: XMLElement,
         supportedRuleTypes: Set<String>,
         rootUri: String,
-        toolchainPath: String
+        toolchainPath: String,
+        buildTestSuffix: String
     ) throws -> [(BuildTarget, [URI])] {
 
         // FIXME: Most of this logic is hacked together and not thought through, with the
@@ -42,7 +43,7 @@ enum BazelQueryParser {
             guard let childElement = child as? XMLElement else { continue }
             let className = childElement.attribute(forName: "class")?.stringValue ?? ""
             guard supportedRuleTypes.contains(className) else { continue }
-            if let data = try getTargetForLibrary(childElement, className, rootUri, toolchainPath) {
+            if let data = try getTargetForLibrary(childElement, className, rootUri, toolchainPath, buildTestSuffix) {
                 targets.append(data)
             }
         }
@@ -53,7 +54,8 @@ enum BazelQueryParser {
         _ childElement: XMLElement,
         _ className: String,
         _ rootUri: String,
-        _ toolchainPath: String
+        _ toolchainPath: String,
+        _ buildTestSuffix: String
     ) throws -> (BuildTarget, [URI])? {
         let bazelTarget = childElement.attribute(forName: "name")?.stringValue ?? ""
         guard bazelTarget.starts(with: "//") else {
@@ -109,9 +111,9 @@ enum BazelQueryParser {
             tags.append(.test)
         }
         // FIXME: This is assuming everything is iOS code. Will soon update this to handle all platforms.
-        let buildTestSuffix = "_ios_skbsp"
-        let uri: URI = try URI(string: uriRaw + buildTestSuffix)
-        let displayName = bazelTarget + buildTestSuffix
+        let platformBuildTestSuffix = "_ios" + buildTestSuffix
+        let uri: URI = try URI(string: uriRaw + platformBuildTestSuffix)
+        let displayName = bazelTarget + platformBuildTestSuffix
         return (
             BuildTarget(
                 id: BuildTargetIdentifier(uri: uri),

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -85,7 +85,8 @@ final class BazelTargetStore {
             from: xml,
             supportedRuleTypes: Self.supportedRuleTypes,
             rootUri: initializedConfig.rootUri,
-            toolchainPath: initializedConfig.devToolchainPath
+            toolchainPath: initializedConfig.devToolchainPath,
+            buildTestSuffix: initializedConfig.baseConfig.buildTestSuffix
         )
 
         // Fill the local cache based on the data we got from the query

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -23,12 +23,10 @@ import LanguageServerProtocol
 
 enum BazelTargetStoreError: Error, LocalizedError {
     case unknownBSPURI(URI)
-    case missingDisplayName(BuildTarget)
 
     var errorDescription: String? {
         switch self {
         case .unknownBSPURI(let uri): return "Requested data about a URI, but couldn't find it in the store: \(uri)"
-        case .missingDisplayName(let target): return "Target \(target.id.uri) is somehow missing a display name"
         }
     }
 }
@@ -92,13 +90,8 @@ final class BazelTargetStore {
 
         // Fill the local cache based on the data we got from the query
         for (target, srcs) in targetData {
-            // FIXME: This is assuming everything is iOS code. Will soon update this to handle all platforms.
-            let buildTestSuffix = "_skbsp_ios"
-            let uri = try URI(string: target.id.uri.stringValue + buildTestSuffix)
-            guard let displayName = target.displayName else {
-                throw BazelTargetStoreError.missingDisplayName(target)
-            }
-            bspURIsToBazelLabelsMap[uri] = displayName + buildTestSuffix
+            let uri = target.id.uri
+            bspURIsToBazelLabelsMap[uri] = target.displayName
             bspURIsToSrcsMap[uri] = srcs
             for src in srcs {
                 srcToBspURIsMap[src, default: []].append(uri)

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -23,10 +23,12 @@ import LanguageServerProtocol
 
 enum BazelTargetStoreError: Error, LocalizedError {
     case unknownBSPURI(URI)
+    case missingDisplayName(BuildTarget)
 
     var errorDescription: String? {
         switch self {
         case .unknownBSPURI(let uri): return "Requested data about a URI, but couldn't find it in the store: \(uri)"
+        case .missingDisplayName(let target): return "Target \(target.id.uri) is somehow missing a display name"
         }
     }
 }
@@ -90,8 +92,13 @@ final class BazelTargetStore {
 
         // Fill the local cache based on the data we got from the query
         for (target, srcs) in targetData {
-            let uri = target.id.uri
-            bspURIsToBazelLabelsMap[uri] = target.displayName
+            // FIXME: This is assuming everything is iOS code. Will soon update this to handle all platforms.
+            let buildTestSuffix = "_skbsp_ios"
+            let uri = try URI(string: target.id.uri.stringValue + buildTestSuffix)
+            guard let displayName = target.displayName else {
+                throw BazelTargetStoreError.missingDisplayName(target)
+            }
+            bspURIsToBazelLabelsMap[uri] = displayName + buildTestSuffix
             bspURIsToSrcsMap[uri] = srcs
             for src in srcs {
                 srcToBspURIsMap[src, default: []].append(uri)

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -44,6 +44,7 @@ final class BazelTargetStore {
     private var bspURIsToBazelLabelsMap: [URI: String] = [:]
     private var bspURIsToSrcsMap: [URI: [URI]] = [:]
     private var srcToBspURIsMap: [URI: [URI]] = [:]
+    var buildCache = Set<URI>()
 
     init(initializedConfig: InitializedServerConfig, bazelTargetQuerier: BazelTargetQuerier = BazelTargetQuerier()) {
         self.initializedConfig = initializedConfig

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -44,7 +44,6 @@ final class BazelTargetStore {
     private var bspURIsToBazelLabelsMap: [URI: String] = [:]
     private var bspURIsToSrcsMap: [URI: [URI]] = [:]
     private var srcToBspURIsMap: [URI: [URI]] = [:]
-    var buildCache = Set<URI>()
 
     init(initializedConfig: InitializedServerConfig, bazelTargetQuerier: BazelTargetQuerier = BazelTargetQuerier()) {
         self.initializedConfig = initializedConfig

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BuildTargetsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BuildTargetsHandler.swift
@@ -45,6 +45,11 @@ final class BuildTargetsHandler {
         do {
             let result = try targetStore.fetchTargets()
             logger.debug("Found \(result.count) targets")
+            logger.logFullObjectInMultipleLogMessages(
+                level: .debug,
+                header: "Target list",
+                result.map { $0.id.uri.stringValue }.joined(separator: ", "),
+            )
             connection?.finishTask(id: taskId, status: .ok)
             return WorkspaceBuildTargetsResponse(targets: result)
         } catch {

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -85,7 +85,6 @@ final class BazelTargetCompilerArgsExtractor {
         if !bazelTarget.hasSuffix(platformBuildTestSuffix) {
             throw BazelTargetCompilerArgsExtractorError.invalidTarget(bazelTarget)
         }
-        // FIXME: This is assuming everything is iOS code. Will soon update this to handle all platforms.
         let underlyingLibrary = String(bazelTarget.dropLast(platformBuildTestSuffix.count))
         let resultAquery = try aquerier.aquery(
             target: bazelTarget,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -80,12 +80,13 @@ final class BazelTargetCompilerArgsExtractor {
 
         // First, run an aquery against the build_test target in question,
         // filtering for the "real" underlying library.
-        let buildTestSuffix = "_skbsp"
-        if !bazelTarget.hasSuffix(buildTestSuffix) {
+        // FIXME: This is assuming everything is iOS code. Will soon update this to handle all platforms.
+        let platformBuildTestSuffix = "_ios" + config.baseConfig.buildTestSuffix
+        if !bazelTarget.hasSuffix(platformBuildTestSuffix) {
             throw BazelTargetCompilerArgsExtractorError.invalidTarget(bazelTarget)
         }
         // FIXME: This is assuming everything is iOS code. Will soon update this to handle all platforms.
-        let underlyingLibrary = String(bazelTarget.dropLast(("_ios" + buildTestSuffix).count))
+        let underlyingLibrary = String(bazelTarget.dropLast(platformBuildTestSuffix.count))
         let resultAquery = try aquerier.aquery(
             target: bazelTarget,
             filteringFor: underlyingLibrary,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -25,10 +25,12 @@ private let logger = makeFileLevelBSPLogger()
 
 enum BazelTargetCompilerArgsExtractorError: Error, LocalizedError {
     case invalidObjCUri(String)
+    case invalidTarget(String)
 
     var errorDescription: String? {
         switch self {
         case .invalidObjCUri(let uri): return "Unexpected non-Swift URI missing root URI prefix: \(uri)"
+        case .invalidTarget(let target): return "Expected to receive a build_test target, but got: \(target)"
         }
     }
 }
@@ -76,17 +78,26 @@ final class BazelTargetCompilerArgsExtractor {
             return cached
         }
 
-        // First, get the root aquery, which contains all the compilation steps for the targets the BSP was configured for.
-        let rootAquery = try aquerier.aquery(
-            forConfig: config,
+        // First, run an aquery against the build_test target in question,
+        // filtering for the "real" underlying library.
+        let buildTestSuffix = "_skbsp"
+        if !bazelTarget.hasSuffix(buildTestSuffix) {
+            throw BazelTargetCompilerArgsExtractorError.invalidTarget(bazelTarget)
+        }
+        // FIXME: This is assuming everything is iOS code. Will soon update this to handle all platforms.
+        let underlyingLibrary = String(bazelTarget.dropLast(("_ios" + buildTestSuffix).count))
+        let resultAquery = try aquerier.aquery(
+            target: bazelTarget,
+            filteringFor: underlyingLibrary,
+            config: config,
             mnemonics: ["SwiftCompile", "ObjcCompile"],
-            additionalFlags: ["--noinclude_artifacts"]
+            additionalFlags: ["--noinclude_artifacts", "--noinclude_aspects"]
         )
 
-        // Then, extract the compiler arguments for the target file from the root aquery.
+        // Then, extract the compiler arguments for the target file from the resulting aquery.
         let processedArgs = CompilerArgumentsProcessor.extractAndProcessCompilerArgs(
-            fromAquery: rootAquery,
-            bazelTarget: bazelTarget,
+            fromAquery: resultAquery,
+            bazelTarget: underlyingLibrary,
             contentToQuery: contentToQuery,
             language: language,
             initializedConfig: config

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/CompilerArgumentsProcessor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/CompilerArgumentsProcessor.swift
@@ -180,6 +180,12 @@ enum CompilerArgumentsProcessor {
                 continue
             }
 
+            // Skip -emit-const-values-path for now, this causes permission issues in bazel-out
+            if arg == "-emit-const-values-path" {
+                index += 2
+                continue
+            }
+
             // Replace SDK placeholder
             if arg.contains("__BAZEL_XCODE_SDKROOT__") {
                 let transformedArg = arg.replacingOccurrences(of: "__BAZEL_XCODE_SDKROOT__", with: sdkRoot)

--- a/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFileChangeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFileChangeHandler.swift
@@ -21,17 +21,22 @@ import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
 
+protocol InvalidatedTargetObserver: AnyObject {
+    func invalidate(targets: Set<URI>) throws
+}
+
 /// Handles the file changing notification.
 ///
 /// This is intended to tell the LSP which targets are invalidated by a change.
 final class WatchedFileChangeHandler {
 
     private let targetStore: BazelTargetStore
-
+    private var observers: [any InvalidatedTargetObserver]
     private weak var connection: LSPConnection?
 
-    init(targetStore: BazelTargetStore, connection: LSPConnection) {
+    init(targetStore: BazelTargetStore, observers: [any InvalidatedTargetObserver] = [], connection: LSPConnection) {
         self.targetStore = targetStore
+        self.observers = observers
         self.connection = connection
     }
 
@@ -47,7 +52,9 @@ final class WatchedFileChangeHandler {
                 affectedTargets.insert(target)
             }
         }
-        targetStore.buildCache.subtract(affectedTargets)
+        for observer in observers {
+            try observer.invalidate(targets: affectedTargets)
+        }
         let response = OnBuildTargetDidChangeNotification(
             changes: affectedTargets.map {
                 BuildTargetEvent(target: BuildTargetIdentifier(uri: $0), kind: .changed, dataKind: nil, data: nil)

--- a/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFileChangeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFileChangeHandler.swift
@@ -47,6 +47,7 @@ final class WatchedFileChangeHandler {
                 affectedTargets.insert(target)
             }
         }
+        targetStore.buildCache.subtract(affectedTargets)
         let response = OnBuildTargetDidChangeNotification(
             changes: affectedTargets.map {
                 BuildTargetEvent(target: BuildTargetIdentifier(uri: $0), kind: .changed, dataKind: nil, data: nil)

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -31,7 +31,13 @@ package struct BaseServerConfig: Equatable {
     let buildTestSuffix: String
     let filesToWatch: String?
 
-    package init(bazelWrapper: String, targets: [String], indexFlags: [String], buildTestSuffix: String, filesToWatch: String?) {
+    package init(
+        bazelWrapper: String,
+        targets: [String],
+        indexFlags: [String],
+        buildTestSuffix: String,
+        filesToWatch: String?
+    ) {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
         self.indexFlags = indexFlags

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -28,12 +28,14 @@ package struct BaseServerConfig: Equatable {
     let bazelWrapper: String
     let targets: [String]
     let indexFlags: [String]
+    let buildTestSuffix: String
     let filesToWatch: String?
 
-    package init(bazelWrapper: String, targets: [String], indexFlags: [String], filesToWatch: String?) {
+    package init(bazelWrapper: String, targets: [String], indexFlags: [String], buildTestSuffix: String, filesToWatch: String?) {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
         self.indexFlags = indexFlags
+        self.buildTestSuffix = buildTestSuffix
         self.filesToWatch = filesToWatch
     }
 }

--- a/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
+++ b/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
@@ -92,7 +92,11 @@ package final class SourceKitBazelBSPServer {
         registry.register(requestHandler: prepareHandler.prepareTarget)
 
         // OnWatchedFilesDidChangeNotification
-        let watchedFileChangeHandler = WatchedFileChangeHandler(targetStore: targetStore, connection: connection)
+        let watchedFileChangeHandler = WatchedFileChangeHandler(
+            targetStore: targetStore,
+            observers: [prepareHandler],
+            connection: connection
+        )
         registry.register(notificationHandler: watchedFileChangeHandler.onWatchedFilesDidChange)
     }
 

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -28,15 +28,10 @@ struct Serve: ParsableCommand {
     @Option(help: "The name of the Bazel CLI to invoke (e.g. 'bazelisk')")
     var bazelWrapper: String = "bazel"
 
-    // FIXME: We should support any library target, not just the app ones.
-    // The problem is that ios_application targets apply transitions that don't get reflected
-    // when building libraries individually. Queries have a --universe_scope flag to account for this,
-    // but this is not available for build actions at the moment. We need to find a stable way of building
-    // libraries with the same configs that would be applied when building the full app.
     @Option(
         parsing: .singleValue,
         help:
-            "The Bazel ios_application or test targets that this should serve a BSP for. Can be specified multiple times."
+            "The *top level* Bazel application or test targets that this should serve a BSP for. Can be specified multiple times."
     )
     var target: [String]
 
@@ -47,6 +42,12 @@ struct Serve: ParsableCommand {
     )
     var indexFlag: [String] = []
 
+    @Option(
+        help:
+            "The expected suffix for build_test targets. Defaults to '_skbsp'."
+    )
+    var buildTestSuffix: String = "_skbsp"
+
     @Option(help: "Comma separated list of file globs to watch for changes.")
     var filesToWatch: String?
 
@@ -56,6 +57,7 @@ struct Serve: ParsableCommand {
             bazelWrapper: bazelWrapper,
             targets: target,
             indexFlags: indexFlag.map { "--" + $0 },
+            buildTestSuffix: buildTestSuffix,
             filesToWatch: filesToWatch
         )
         let server = SourceKitBazelBSPServer(baseConfig: config)

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -34,6 +34,7 @@ struct BazelTargetQuerierTests {
             bazelWrapper: "bazelisk",
             targets: ["//HelloWorld"],
             indexFlags: ["--config=test"],
+            buildTestSuffix: "_skbsp",
             filesToWatch: nil
         )
 
@@ -60,6 +61,7 @@ struct BazelTargetQuerierTests {
             bazelWrapper: "bazelisk",
             targets: ["//HelloWorld", "//Tests"],
             indexFlags: ["--config=test"],
+            buildTestSuffix: "_skbsp",
             filesToWatch: nil
         )
 
@@ -87,6 +89,7 @@ struct BazelTargetQuerierTests {
             bazelWrapper: "bazel",
             targets: ["//HelloWorld"],
             indexFlags: [],
+            buildTestSuffix: "_skbsp",
             filesToWatch: nil
         )
 

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -34,6 +34,7 @@ struct InitializeHandlerTests {
             bazelWrapper: "mybazel",
             targets: ["//HelloWorld"],
             indexFlags: ["--config=index"],
+            buildTestSuffix: "_skbsp",
             filesToWatch: nil
         )
 
@@ -82,6 +83,7 @@ struct InitializeHandlerTests {
             bazelWrapper: "mybazel",
             targets: ["//HelloWorld"],
             indexFlags: [],
+            buildTestSuffix: "_skbsp",
             filesToWatch: nil
         )
 
@@ -117,6 +119,7 @@ struct InitializeHandlerTests {
             bazelWrapper: "mybazel",
             targets: ["//HelloWorld"],
             indexFlags: ["--config=index1", "--config=index2"],
+            buildTestSuffix: "_skbsp",
             filesToWatch: nil
         )
 

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -37,6 +37,7 @@ struct PrepareHandlerTests {
             bazelWrapper: "bazel",
             targets: ["//HelloWorld"],
             indexFlags: ["--config=index"],
+            buildTestSuffix: "_skbsp",
             filesToWatch: nil
         )
 
@@ -76,6 +77,7 @@ struct PrepareHandlerTests {
             bazelWrapper: "bazel",
             targets: ["//HelloWorld", "//HelloWorld2"],
             indexFlags: ["--config=index"],
+            buildTestSuffix: "_skbsp",
             filesToWatch: nil
         )
 


### PR DESCRIPTION
This PR adds an initial support for having the `prepare/` request build targets individually instead of always trying to build the full apps, providing a massive performance boost overall in exchange for a slight regression for each individual call (which I intend to improve separately).

Currently the logic is hardcoded to only work for iOS apps, but I'll work on expanding this to work with all platforms right after this.

Also makes a small fix to the compiler args parsing (skipping an arg that causes issues sometimes)