### PR TITLE
Update WatchedFileChangeHandler.swift to listen for created and deleted changes

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BazelTargetStoreProtocol.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BazelTargetStoreProtocol.swift
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import LanguageServerProtocol
+
+/// Protocol defining the minimal interface needed for a target store
+protocol BazelTargetStoreProtocol {
+    /// Clear any cached target information
+    func clearCache()
+
+    /// Fetch and update target information from Bazel
+    func fetchTargets() throws -> [BuildTarget]
+
+    /// Get the BSP URIs of targets that contain a given source file
+    func bspURIs(containingSrc src: URI) throws -> [URI]
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -75,6 +75,7 @@ final class BazelTargetStore {
         return bspURIs
     }
 
+    @discardableResult
     func fetchTargets() throws -> [BuildTarget] {
         var targetData: [(BuildTarget, [URI])] = []
         let targets: [BlazeQuery_Target] = try bazelTargetQuerier.queryTargets(

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -34,8 +34,7 @@ enum BazelTargetStoreError: Error, LocalizedError {
 
 /// Abstraction that can queries, processes, and stores the project's dependency graph and its files.
 /// Used by many of the requests to calculate and provide data about the project's targets.
-final class BazelTargetStore {
-
+final class BazelTargetStore: BazelTargetStoreProtocol {
     // The list of rules we currently care about and can process
     static let supportedRuleTypes: Set<String> = ["source file", "swift_library", "objc_library"]
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -142,7 +142,7 @@ final class InitializeHandler {
         let rootUri = initializedConfig.rootUri
         if let filesToWatch = initializedConfig.baseConfig.filesToWatch {
             watchers = filesToWatch.components(separatedBy: ",").map {
-                FileSystemWatcher(globPattern: rootUri + "/" + $0)
+                FileSystemWatcher(globPattern: rootUri + "/" + $0, kind: [.change, .create, .delete])
             }
         } else {
             watchers = nil

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InvalidatedTargetObserver.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InvalidatedTargetObserver.swift
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import LanguageServerProtocol
+
+/// Represents a target that was affected by a file change
+struct AffectedTarget: Hashable {
+    let uri: URI  // Build target URI, not document URI
+    let kind: FileChangeType
+}
+
+/// Protocol for objects that need to be notified when build targets are invalidated
+protocol InvalidatedTargetObserver: AnyObject {
+    func invalidate(targets: Set<AffectedTarget>) throws
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -87,8 +87,10 @@ final class PrepareHandler {
 }
 
 extension PrepareHandler: InvalidatedTargetObserver {
-    func invalidate(targets: Set<URI>) throws {
-        buildCache.subtract(targets)
+    func invalidate(targets: Set<AffectedTarget>) throws {
+        // Extract just the URIs from the affected targets for the build cache
+        let targetURIs = Set(targets.map(\.uri))
+        buildCache.subtract(targetURIs)
     }
 
     func invalidateBuildCache() {

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
@@ -26,7 +26,7 @@ private let logger = makeFileLevelBSPLogger()
 /// Handles the `textDocument/sourceKitOptions` request.
 ///
 /// Returns the compiler arguments for the provided target based on previously gathered information.
-final class SKOptionsHandler {
+final class SKOptionsHandler: InvalidatedTargetObserver {
 
     private let initializedConfig: InitializedServerConfig
     private let targetStore: BazelTargetStore
@@ -85,5 +85,14 @@ final class SKOptionsHandler {
             compilerArguments: args,
             workingDirectory: initializedConfig.rootUri
         )
+    }
+
+    // MARK: - InvalidatedTargetObserver
+
+    func invalidate(targets: Set<AffectedTarget>) throws {
+        // Only clear cache if at least one file was created or deleted
+        if targets.contains(where: { $0.kind == .created || $0.kind == .deleted }) {
+            extractor.clearCache()
+        }
     }
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFileChangeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFileChangeHandler.swift
@@ -27,11 +27,15 @@ private let logger = makeFileLevelBSPLogger()
 ///
 /// This is intended to tell the LSP which targets are invalidated by a change.
 final class WatchedFileChangeHandler {
-    private let targetStore: BazelTargetStore
+    private let targetStore: BazelTargetStoreProtocol
     private var observers: [any InvalidatedTargetObserver]
     private weak var connection: LSPConnection?
 
-    init(targetStore: BazelTargetStore, observers: [any InvalidatedTargetObserver] = [], connection: LSPConnection) {
+    init(
+        targetStore: BazelTargetStoreProtocol,
+        observers: [any InvalidatedTargetObserver] = [],
+        connection: LSPConnection
+    ) {
         self.targetStore = targetStore
         self.observers = observers
         self.connection = connection
@@ -58,7 +62,7 @@ final class WatchedFileChangeHandler {
         if notification.changes.contains(where: { $0.type == .created }) {
             targetStore.clearCache()
             do {
-                try targetStore.fetchTargets()
+                _ = try targetStore.fetchTargets()
             } catch {
                 logger.error("Error fetching targets after file creation: \(error)")
                 // Continue processing with existing target store data

--- a/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFileChangeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFileChangeHandler.swift
@@ -21,15 +21,12 @@ import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
 
-protocol InvalidatedTargetObserver: AnyObject {
-    func invalidate(targets: Set<URI>) throws
-}
+private let logger = makeFileLevelBSPLogger()
 
 /// Handles the file changing notification.
 ///
 /// This is intended to tell the LSP which targets are invalidated by a change.
 final class WatchedFileChangeHandler {
-
     private let targetStore: BazelTargetStore
     private var observers: [any InvalidatedTargetObserver]
     private weak var connection: LSPConnection?
@@ -41,25 +38,98 @@ final class WatchedFileChangeHandler {
     }
 
     func onWatchedFilesDidChange(_ notification: OnWatchedFilesDidChangeNotification) throws {
-        // FIXME: This only deals with changes, not deletions or creations
-        // For those, we need to invalidate the compilation options cache too
-        // and probably also re-compile the app
-        let changes = notification.changes.filter { $0.type == .changed }.map { $0.uri }
-        var affectedTargets: Set<URI> = []
-        for change in changes {
-            let targetsForSrc = try targetStore.bspURIs(containingSrc: change)
-            for target in targetsForSrc {
-                affectedTargets.insert(target)
+        // First, calculate deleted targets before we clear them from the targetStore
+        let deletedTargets = {
+            do {
+                return try notification.changes
+                    .filter { $0.type == .deleted }
+                    .flatMap { change -> [AffectedTarget] in
+                        try targetStore.bspURIs(containingSrc: change.uri)
+                            .map { AffectedTarget(uri: $0, kind: change.type) }
+                    }
+            } catch {
+                logger.error("Error calculating deleted targets: \(error)")
+                return []
+            }
+        }()
+
+        // If there are any 'created' files, we need to clear the targetStore and fetch targets again
+        // Otherwise, the targetStore won't know about them
+        if notification.changes.contains(where: { $0.type == .created }) {
+            targetStore.clearCache()
+            do {
+                try targetStore.fetchTargets()
+            } catch {
+                logger.error("Error fetching targets after file creation: \(error)")
+                // Continue processing with existing target store data
             }
         }
+
+        // Now that the targetStore knows about the newly created files, we can calculate the created targets
+        let createdTargets = {
+            do {
+                return try notification.changes
+                    .filter { $0.type == .created }
+                    .flatMap { change -> [AffectedTarget] in
+                        try targetStore.bspURIs(containingSrc: change.uri)
+                            .map { AffectedTarget(uri: $0, kind: change.type) }
+                    }
+            } catch {
+                logger.error("Error calculating created targets: \(error)")
+                return []
+            }
+        }()
+
+        // Finally, calculate the changed targets
+        let changedTargets = {
+            do {
+                return try notification.changes
+                    .filter { $0.type == .changed }
+                    .flatMap { change -> [AffectedTarget] in
+                        try targetStore.bspURIs(containingSrc: change.uri)
+                            .map { AffectedTarget(uri: $0, kind: change.type) }
+                    }
+            } catch {
+                logger.error("Error calculating changed targets: \(error)")
+                return []
+            }
+        }()
+
+        let affectedTargets: Set<AffectedTarget> = Set(deletedTargets + createdTargets + changedTargets)
+
+        // Invalidate our observers about the affected targets
         for observer in observers {
-            try observer.invalidate(targets: affectedTargets)
+            do {
+                try observer.invalidate(targets: affectedTargets)
+            } catch {
+                logger.error("Error invalidating observer: \(error)")
+                // Continue with other observers
+            }
         }
+
+        // Notify SK-LSP about the affected targets
         let response = OnBuildTargetDidChangeNotification(
-            changes: affectedTargets.map {
-                BuildTargetEvent(target: BuildTargetIdentifier(uri: $0), kind: .changed, dataKind: nil, data: nil)
+            changes: affectedTargets.map { target in
+                BuildTargetEvent(
+                    target: BuildTargetIdentifier(uri: target.uri),
+                    kind: target.kind.buildTargetEventKind,
+                    dataKind: nil,
+                    data: nil
+                )
             }
         )
+
         connection?.send(response)
+    }
+}
+
+extension FileChangeType {
+    fileprivate var buildTargetEventKind: BuildTargetEventKind? {
+        switch self {
+        case .changed: return .changed
+        case .created: return .created
+        case .deleted: return .deleted
+        default: return nil
+        }
     }
 }

--- a/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
+++ b/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
@@ -94,7 +94,7 @@ package final class SourceKitBazelBSPServer {
         // OnWatchedFilesDidChangeNotification
         let watchedFileChangeHandler = WatchedFileChangeHandler(
             targetStore: targetStore,
-            observers: [prepareHandler],
+            observers: [prepareHandler, skOptionsHandler],
             connection: connection
         )
         registry.register(notificationHandler: watchedFileChangeHandler.onWatchedFilesDidChange)

--- a/Tests/SourceKitBazelBSPTests/WatchedFileChangeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/WatchedFileChangeHandlerTests.swift
@@ -1,0 +1,410 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import Foundation
+import LanguageServerProtocol
+import Testing
+
+@testable import SourceKitBazelBSP
+
+@Suite
+struct WatchedFileChangeHandlerTests {
+    // MARK: - Mock Implementations
+
+    final class MockBazelTargetStore: BazelTargetStoreProtocol {
+        var clearCacheCalled = false
+        var fetchTargetsCalled = false
+        var fetchTargetsError: Error?
+        var mockSrcToBspURIs: [DocumentURI: [DocumentURI]] = [:]
+
+        func clearCache() {
+            clearCacheCalled = true
+        }
+
+        func fetchTargets() throws -> [BuildTarget] {
+            fetchTargetsCalled = true
+            if let error = fetchTargetsError {
+                throw error
+            }
+            return []
+        }
+
+        func bspURIs(containingSrc src: DocumentURI) throws -> [DocumentURI] {
+            if let uris = mockSrcToBspURIs[src] {
+                return uris
+            }
+            throw BazelTargetStoreError.unknownBSPURI(src)
+        }
+    }
+
+    final class MockLSPConnection: LSPConnection {
+        nonisolated(unsafe) var sentNotifications: [any NotificationType] = []
+
+        func start(receiveHandler _: MessageHandler, closeHandler _: @escaping @Sendable () async -> Void) {
+            // Not used in these tests
+        }
+
+        func nextRequestID() -> LanguageServerProtocol.RequestID {
+            .number(1)
+        }
+
+        func send(_ notification: some NotificationType) {
+            sentNotifications.append(notification)
+        }
+
+        func send<Request>(
+            _: Request,
+            id _: LanguageServerProtocol.RequestID,
+            reply _: @escaping @Sendable (LanguageServerProtocol.LSPResult<Request.Response>) -> Void
+        ) where Request: LanguageServerProtocol.RequestType {
+            // Not used in these tests
+        }
+
+        func startWorkTask(id _: TaskId, title _: String) {
+            // Not used in these tests
+        }
+
+        func finishTask(id _: TaskId, status _: StatusCode) {
+            // Not used in these tests
+        }
+    }
+
+    final class MockInvalidatedTargetObserver: InvalidatedTargetObserver {
+        var invalidatedTargets: Set<AffectedTarget> = []
+        var invalidateCalled = false
+        var shouldThrowOnInvalidate = false
+
+        func invalidate(targets: Set<AffectedTarget>) throws {
+            invalidateCalled = true
+            invalidatedTargets = targets
+            if shouldThrowOnInvalidate {
+                throw TestError.intentional
+            }
+        }
+    }
+
+    enum TestError: Error {
+        case intentional
+    }
+
+    // MARK: - Helper Methods
+
+    private func createHandler() -> (
+        handler: WatchedFileChangeHandler,
+        targetStore: MockBazelTargetStore,
+        connection: MockLSPConnection,
+        observer: MockInvalidatedTargetObserver
+    ) {
+        let targetStore = MockBazelTargetStore()
+        let connection = MockLSPConnection()
+        let observer = MockInvalidatedTargetObserver()
+        let handler = WatchedFileChangeHandler(
+            targetStore: targetStore,
+            observers: [observer],
+            connection: connection
+        )
+
+        return (handler, targetStore, connection, observer)
+    }
+
+    private func makeURI(_ path: String) throws -> DocumentURI {
+        try DocumentURI(string: path)
+    }
+
+    // MARK: - Tests
+
+    @Test
+    func deletedFiles() throws {
+        // Arrange
+        let (handler, targetStore, connection, observer) = createHandler()
+
+        let fileURI = try makeURI("file:///path/to/project/Sources/MyFile.swift")
+        let targetURI1 = try makeURI("build://target1")
+        let targetURI2 = try makeURI("build://target2")
+
+        // Set up the target store to return targets for the deleted file
+        targetStore.mockSrcToBspURIs[fileURI] = [targetURI1, targetURI2]
+
+        let notification = OnWatchedFilesDidChangeNotification(
+            changes: [
+                FileEvent(uri: fileURI, type: .deleted)
+            ]
+        )
+
+        // Act
+        try handler.onWatchedFilesDidChange(notification)
+
+        // Assert
+        #expect(!targetStore.clearCacheCalled, "clearCache should not be called for deleted files")
+        #expect(!targetStore.fetchTargetsCalled, "fetchTargets should not be called for deleted files")
+
+        // Check that the observer was notified
+        #expect(observer.invalidateCalled)
+        #expect(observer.invalidatedTargets.count == 2)
+        #expect(observer.invalidatedTargets.contains(AffectedTarget(uri: targetURI1, kind: .deleted)))
+        #expect(observer.invalidatedTargets.contains(AffectedTarget(uri: targetURI2, kind: .deleted)))
+
+        // Check that the LSP connection received the notification
+        #expect(connection.sentNotifications.count == 1)
+        if let sentNotification = connection.sentNotifications.first as? OnBuildTargetDidChangeNotification {
+            #expect(sentNotification.changes?.count == 2)
+
+            let expectedTargetURIs = Set([targetURI1, targetURI2])
+            if let changes = sentNotification.changes {
+                let actualTargetURIs = Set(changes.map { $0.target.uri })
+                #expect(actualTargetURIs == expectedTargetURIs)
+
+                for change in changes {
+                    #expect(change.kind == .deleted)
+                }
+            }
+        } else {
+            Issue.record("Expected OnBuildTargetDidChangeNotification")
+        }
+    }
+
+    @Test
+    func createdFiles() throws {
+        // Arrange
+        let (handler, targetStore, connection, observer) = createHandler()
+
+        let fileURI = try makeURI("file:///path/to/project/Sources/NewFile.swift")
+        let targetURI = try makeURI("build://newTarget")
+
+        // Set up the target store to return a target for the created file after fetchTargets is called
+        targetStore.mockSrcToBspURIs[fileURI] = [targetURI]
+
+        let notification = OnWatchedFilesDidChangeNotification(
+            changes: [
+                FileEvent(uri: fileURI, type: .created)
+            ]
+        )
+
+        // Act
+        try handler.onWatchedFilesDidChange(notification)
+
+        // Assert
+        #expect(targetStore.clearCacheCalled, "clearCache should be called for created files")
+        #expect(targetStore.fetchTargetsCalled, "fetchTargets should be called for created files")
+
+        // Check that the observer was notified
+        #expect(observer.invalidateCalled)
+        #expect(observer.invalidatedTargets.count == 1)
+        #expect(observer.invalidatedTargets.contains(AffectedTarget(uri: targetURI, kind: .created)))
+
+        // Check that the LSP connection received the notification
+        #expect(connection.sentNotifications.count == 1)
+        if let sentNotification = connection.sentNotifications.first as? OnBuildTargetDidChangeNotification {
+            #expect(sentNotification.changes?.count == 1)
+            #expect(sentNotification.changes?[0].target.uri == targetURI)
+            #expect(sentNotification.changes?[0].kind == .created)
+        } else {
+            Issue.record("Expected OnBuildTargetDidChangeNotification")
+        }
+    }
+
+    @Test
+    func updatedFiles() throws {
+        // Arrange
+        let (handler, targetStore, connection, observer) = createHandler()
+
+        let fileURI = try makeURI("file:///path/to/project/Sources/UpdatedFile.swift")
+        let targetURI = try makeURI("build://updatedTarget")
+
+        // Set up the target store to return a target for the updated file
+        targetStore.mockSrcToBspURIs[fileURI] = [targetURI]
+
+        let notification = OnWatchedFilesDidChangeNotification(
+            changes: [
+                FileEvent(uri: fileURI, type: .changed)
+            ]
+        )
+
+        // Act
+        try handler.onWatchedFilesDidChange(notification)
+
+        // Assert
+        #expect(!targetStore.clearCacheCalled, "clearCache should not be called for changed files")
+        #expect(!targetStore.fetchTargetsCalled, "fetchTargets should not be called for changed files")
+
+        // Check that the observer was notified
+        #expect(observer.invalidateCalled)
+        #expect(observer.invalidatedTargets.count == 1)
+        #expect(observer.invalidatedTargets.contains(AffectedTarget(uri: targetURI, kind: .changed)))
+
+        // Check that the LSP connection received the notification
+        #expect(connection.sentNotifications.count == 1)
+        if let sentNotification = connection.sentNotifications.first as? OnBuildTargetDidChangeNotification {
+            #expect(sentNotification.changes?.count == 1)
+            #expect(sentNotification.changes?[0].target.uri == targetURI)
+            #expect(sentNotification.changes?[0].kind == .changed)
+        } else {
+            Issue.record("Expected OnBuildTargetDidChangeNotification")
+        }
+    }
+
+    @Test
+    func mixedFileChanges() throws {
+        // Arrange - test with multiple file changes of different types in one notification
+        let (handler, targetStore, connection, observer) = createHandler()
+
+        let deletedFileURI = try makeURI("file:///path/to/project/Sources/DeletedFile.swift")
+        let createdFileURI = try makeURI("file:///path/to/project/Sources/CreatedFile.swift")
+        let changedFileURI = try makeURI("file:///path/to/project/Sources/ChangedFile.swift")
+
+        let deletedTargetURI = try makeURI("build://deletedTarget")
+        let createdTargetURI = try makeURI("build://createdTarget")
+        let changedTargetURI = try makeURI("build://changedTarget")
+
+        targetStore.mockSrcToBspURIs[deletedFileURI] = [deletedTargetURI]
+        targetStore.mockSrcToBspURIs[createdFileURI] = [createdTargetURI]
+        targetStore.mockSrcToBspURIs[changedFileURI] = [changedTargetURI]
+
+        let notification = OnWatchedFilesDidChangeNotification(
+            changes: [
+                FileEvent(uri: deletedFileURI, type: .deleted),
+                FileEvent(uri: createdFileURI, type: .created),
+                FileEvent(uri: changedFileURI, type: .changed),
+            ]
+        )
+
+        // Act
+        try handler.onWatchedFilesDidChange(notification)
+
+        // Assert
+        #expect(targetStore.clearCacheCalled, "clearCache should be called when there are created files")
+        #expect(targetStore.fetchTargetsCalled, "fetchTargets should be called when there are created files")
+
+        // Check that the observer was notified with all affected targets
+        #expect(observer.invalidateCalled)
+        #expect(observer.invalidatedTargets.count == 3)
+        #expect(observer.invalidatedTargets.contains(AffectedTarget(uri: deletedTargetURI, kind: .deleted)))
+        #expect(observer.invalidatedTargets.contains(AffectedTarget(uri: createdTargetURI, kind: .created)))
+        #expect(observer.invalidatedTargets.contains(AffectedTarget(uri: changedTargetURI, kind: .changed)))
+
+        // Check that the LSP connection received the notification with all changes
+        #expect(connection.sentNotifications.count == 1)
+        if let sentNotification = connection.sentNotifications.first as? OnBuildTargetDidChangeNotification {
+            #expect(sentNotification.changes?.count == 3)
+
+            if let notificationChanges = sentNotification.changes {
+                let changes = notificationChanges.map { (uri: $0.target.uri, kind: $0.kind) }
+                #expect(changes.contains { $0.uri == deletedTargetURI && $0.kind == .deleted })
+                #expect(changes.contains { $0.uri == createdTargetURI && $0.kind == .created })
+                #expect(changes.contains { $0.uri == changedTargetURI && $0.kind == .changed })
+            }
+        } else {
+            Issue.record("Expected OnBuildTargetDidChangeNotification")
+        }
+    }
+
+    @Test
+    func fileWithNoAssociatedTargets() throws {
+        // Arrange - test handling of files that don't belong to any target
+        let (handler, _, connection, observer) = createHandler()
+
+        let fileURI = try makeURI("file:///path/to/project/Sources/OrphanFile.swift")
+        // Don't set up any targets for this file - bspURIs will throw an error
+
+        let notification = OnWatchedFilesDidChangeNotification(
+            changes: [
+                FileEvent(uri: fileURI, type: .changed)
+            ]
+        )
+
+        // Act
+        try handler.onWatchedFilesDidChange(notification)
+
+        // Assert - should handle gracefully without targets
+        // The observer is still called but with an empty set when files have no targets
+        #expect(observer.invalidateCalled, "Observer should be called even for files with no targets")
+        #expect(observer.invalidatedTargets.isEmpty, "No targets should be invalidated for orphan files")
+
+        #expect(connection.sentNotifications.count == 1)
+        if let sentNotification = connection.sentNotifications.first as? OnBuildTargetDidChangeNotification {
+            #expect(sentNotification.changes?.isEmpty ?? true)
+        } else {
+            Issue.record("Expected OnBuildTargetDidChangeNotification")
+        }
+    }
+
+    @Test
+    func errorHandlingDuringFetchTargets() throws {
+        // Arrange - test that errors during fetchTargets are handled gracefully
+        let (handler, targetStore, connection, observer) = createHandler()
+
+        let fileURI = try makeURI("file:///path/to/project/Sources/NewFile.swift")
+        let targetURI = try makeURI("build://newTarget")
+
+        targetStore.mockSrcToBspURIs[fileURI] = [targetURI]
+        targetStore.fetchTargetsError = TestError.intentional
+
+        let notification = OnWatchedFilesDidChangeNotification(
+            changes: [
+                FileEvent(uri: fileURI, type: .created)
+            ]
+        )
+
+        // Act
+        try handler.onWatchedFilesDidChange(notification)
+
+        // Assert - the handler should continue processing despite the error
+        #expect(targetStore.clearCacheCalled)
+        #expect(targetStore.fetchTargetsCalled)
+
+        // The observer should still be notified
+        #expect(observer.invalidateCalled)
+        #expect(observer.invalidatedTargets.count == 1)
+
+        // The LSP connection should still receive a notification
+        #expect(connection.sentNotifications.count == 1)
+    }
+
+    @Test
+    func errorHandlingDuringObserverInvalidation() throws {
+        // Arrange - test that errors from observers don't stop processing
+        let (handler, targetStore, connection, observer) = createHandler()
+
+        let fileURI = try makeURI("file:///path/to/project/Sources/File.swift")
+        let targetURI = try makeURI("build://target")
+
+        targetStore.mockSrcToBspURIs[fileURI] = [targetURI]
+        observer.shouldThrowOnInvalidate = true
+
+        let notification = OnWatchedFilesDidChangeNotification(
+            changes: [
+                FileEvent(uri: fileURI, type: .changed)
+            ]
+        )
+
+        // Act
+        try handler.onWatchedFilesDidChange(notification)
+
+        // Assert - despite the observer error, the LSP connection should still receive notification
+        #expect(observer.invalidateCalled)
+        #expect(connection.sentNotifications.count == 1)
+        if let sentNotification = connection.sentNotifications.first as? OnBuildTargetDidChangeNotification {
+            #expect(sentNotification.changes?.count == 1)
+            #expect(sentNotification.changes?[0].target.uri == targetURI)
+        } else {
+            Issue.record("Expected OnBuildTargetDidChangeNotification")
+        }
+    }
+}


### PR DESCRIPTION
Support adding / deleting files, and having those changes be successfully handled by our build server.