### PR TITLE
Remove custom symlink from the example proj

### DIFF
--- a/Example/.bazelrc
+++ b/Example/.bazelrc
@@ -19,7 +19,6 @@ common --features=swift.use_global_module_cache
 common --features=swift.emit_swiftsourceinfo
 build --noworker_sandboxing
 build --spawn_strategy=remote,worker,local
-build --symlink_prefix=custom-out/
 
 # Only for BSP builds
 common:index_build --experimental_convenience_symlinks=ignore


### PR DESCRIPTION
Was breaking the example proj.