### PR TITLE
Add base support for request cancelation

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/Cancel/CancelRequestHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/Cancel/CancelRequestHandler.swift
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import Foundation
+import LanguageServerProtocol
+
+private let logger = makeFileLevelBSPLogger()
+
+/// Handles the cancel request notification.
+///
+/// Does nothing but relay the cancel request to its observers.
+final class CancelRequestHandler {
+    private var observers: [any CancelRequestObserver]
+
+    init(observers: [any CancelRequestObserver] = []) {
+        self.observers = observers
+    }
+
+    func onCancelRequest(_ notification: CancelRequestNotification) throws {
+        for observer in observers {
+            try observer.cancel(request: notification.id)
+        }
+    }
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/Cancel/CancelRequestObserver.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/Cancel/CancelRequestObserver.swift
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import LanguageServerProtocol
+
+/// Protocol for objects that need to be notified of cancellation requests.
+protocol CancelRequestObserver: AnyObject {
+    func cancel(request: RequestID) throws
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -99,3 +99,11 @@ extension PrepareHandler: InvalidatedTargetObserver {
         buildCache.removeAll()
     }
 }
+
+// When the user changes targets in the IDE in the middle of a background index request,
+// the LSP asks us to cancel the background one to be able to prioritize the IDE one.
+extension PrepareHandler: CancelRequestObserver {
+    func cancel(request: RequestID) throws {
+        // no-op, to be implemented
+    }
+}

--- a/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
+++ b/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
@@ -57,9 +57,6 @@ package final class SourceKitBazelBSPServer {
         registry.register(notificationHandler: { (_: OnBuildInitializedNotification) in
             // no-op
         })
-        registry.register(notificationHandler: { (_: CancelRequestNotification) in
-            // no-op, no request canceling since the code today is not async
-        })
         registry.register(requestHandler: { (_: WorkspaceWaitForBuildSystemUpdatesRequest, _: RequestID) in
             // FIXME: no-op, no special handling since the code today is not async, but I might be wrong here.
             VoidResponse()
@@ -98,6 +95,12 @@ package final class SourceKitBazelBSPServer {
             connection: connection
         )
         registry.register(notificationHandler: watchedFileChangeHandler.onWatchedFilesDidChange)
+
+        // CancelRequestNotification
+        let cancelRequestHandler = CancelRequestHandler(
+            observers: [prepareHandler] // `prepare` is the only case of cancelation I'm aware of.
+        )
+        registry.register(notificationHandler: cancelRequestHandler.onCancelRequest)
     }
 
     package convenience init(

--- a/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
+++ b/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
@@ -98,7 +98,7 @@ package final class SourceKitBazelBSPServer {
 
         // CancelRequestNotification
         let cancelRequestHandler = CancelRequestHandler(
-            observers: [prepareHandler] // `prepare` is the only case of cancelation I'm aware of.
+            observers: [prepareHandler]  // `prepare` is the only case of cancelation I'm aware of.
         )
         registry.register(notificationHandler: cancelRequestHandler.onCancelRequest)
     }


### PR DESCRIPTION
I discovered recently that the LSP will send us cancelation requests if the user changes targets in the IDE in the middle of a background index request. This adds the base structure for it, with the implementation coming in a follow-up PR (will need to make a couple of things async)