### PR TITLE
Build out makefile for making release archives

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,3 +35,10 @@ jobs:
         run: |
           cd Example
           bazelisk test //HelloWorld:HelloWorldTests
+      - name: Build release source archive
+        run: make release_source_archive
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release.tar.gz
+          path: archives/release.tar.gz
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__
 /.vscode/
 swift-cmark
 bazel-*
+archives/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: release_source_archive
+release_source_archive:
+	mkdir -p archives
+	tar --exclude-vcs \
+		--exclude=bazel-* \
+		--exclude=.github \
+		--exclude=archives \
+		--exclude=.bsp \
+		--exclude=.build \
+		--exclude=.DS_Store \
+		--exclude=.vscode \
+		--exclude=Example \
+		--exclude=.index-build \
+		--exclude=.swift-format \
+		--exclude=.editorconfig \
+		-zcf "archives/release.tar.gz" .


### PR DESCRIPTION
This will be needed during releases for publishing to the BCR which requires source archives