### PR TITLE
Optimize the dependency graph calculation

### DIFF
--- a/Example/HelloWorld/BUILD
+++ b/Example/HelloWorld/BUILD
@@ -155,13 +155,13 @@ ios_application(
 watchos_application(
     name = "HelloWorldWatchApp",
     bundle_id = "com.example.HelloWorld.Watch",
-    extensions = [":HelloWorld-WatchExtension"],
+    extensions = [":HelloWorldWatchExtension"],
     infoplists = ["Resources/WatchApp-Info.plist"],
     minimum_os_version = WATCHOS_MINIMUM_OS_VERSION,
 )
 
 watchos_extension(
-    name = "HelloWorldWatchExt",
+    name = "HelloWorldWatchExtension",
     bundle_id = "com.example.HelloWorld.Watch.extension",
     infoplists = ["Resources/WatchExt-Info.plist"],
     minimum_os_version = WATCHOS_MINIMUM_OS_VERSION,

--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,9 @@ let package = Package(
                     name: "ArgumentParser",
                     package: "swift-argument-parser"
                 ),
+            ],
+            exclude: [
+                "BUILD",
             ]
         ),
         .target(
@@ -46,6 +49,9 @@ let package = Package(
                     package: "sourcekit-lsp"
                 ),
             ],
+            exclude: [
+                "BUILD",
+            ]
         ),
         .testTarget(
             name: "SourceKitBazelBSPTests",
@@ -62,6 +68,7 @@ let package = Package(
                 .product(name: "SwiftProtobuf", package: "swift-protobuf")
             ],
             exclude: [
+                "BUILD",
                 "README.md",
                 "protos/analysis_v2.proto",
                 "protos/build.proto",

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -208,7 +208,8 @@ final class BazelTargetStoreImpl: BazelTargetStore {
         return targetData.map { $0.0 }
     }
 
-    private func traverseGraph(from target: String, in graph: [String: [String]], ignoring: Set<String>) -> Set<String> {
+    private func traverseGraph(from target: String, in graph: [String: [String]], ignoring: Set<String>) -> Set<String>
+    {
         var visited = Set<String>()
         var result = Set<String>()
         var queue: [String] = graph[target, default: []]

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -138,11 +138,15 @@ final class BazelTargetStoreImpl: BazelTargetStore {
             forConfig: initializedConfig.baseConfig,
             rootUri: initializedConfig.rootUri,
         )
+        let topLevelTargets = topLevelTargetData.map { $0.0 }
 
         logger.debug("Queried top-level target data: \(topLevelTargetData)")
 
+        // Parse the target dependencies for the top-level targets.
+        // This doesn't include information about which top-level app a target belongs to,
+        // but we'll fill that in below.
         let targets: [BlazeQuery_Target] = try bazelTargetQuerier.queryTargetDependencies(
-            forTargets: topLevelTargetData.map { $0.0 },
+            forTargets: topLevelTargets,
             forConfig: initializedConfig.baseConfig,
             rootUri: initializedConfig.rootUri,
             kinds: Self.supportedKinds
@@ -174,13 +178,19 @@ final class BazelTargetStoreImpl: BazelTargetStore {
 
         // We need to now map which targets belong to which top-level apps,
         // to further support the target / platform combo differentiation mentioned above.
-        for (topLevelTarget, _) in topLevelTargetData {
-            let deps = try bazelTargetQuerier.queryDependencyLabels(
-                ofTarget: topLevelTarget,
-                forConfig: initializedConfig.baseConfig,
-                rootUri: initializedConfig.rootUri,
-                kinds: Self.supportedKinds
-            )
+
+        // We need to include the top-level here data as well to be able to traverse the graph correctly.
+        let depGraphKinds = Self.supportedKinds.union(TopLevelRuleType.allCases.map { $0.rawValue })
+
+        let depGraph = try bazelTargetQuerier.queryDependencyGraph(
+            ofTargets: topLevelTargets,
+            forConfig: initializedConfig.baseConfig,
+            rootUri: initializedConfig.rootUri,
+            kinds: depGraphKinds
+        )
+
+        for topLevelTarget in topLevelTargets {
+            let deps = traverseGraph(from: topLevelTarget, in: depGraph)
             for dep in deps {
                 guard availableBazelLabels.contains(dep) else {
                     // Ignore any labels that we also ignored above
@@ -191,6 +201,22 @@ final class BazelTargetStoreImpl: BazelTargetStore {
         }
 
         return targetData.map { $0.0 }
+    }
+
+    private func traverseGraph(from target: String, in graph: [String: [String]]) -> Set<String> {
+        var visited = Set<String>()
+        var result = Set<String>()
+        var queue: [String] = graph[target, default: []]
+        while let curr = queue.popLast() {
+            result.insert(curr)
+            for dep in graph[curr, default: []] {
+                if !visited.contains(dep) {
+                    visited.insert(dep)
+                    queue.append(dep)
+                }
+            }
+        }
+        return result
     }
 
     func clearCache() {


### PR DESCRIPTION
This changes one section of the dependency graph calculation logic to do one big bazel query instead of individual queries per top-level app, by requesting the data with `--output graph` and parsing the result.

Also fixes the integration with the watch app.