### PR TITLE
Add base support for async requests

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -58,7 +58,7 @@ final class InitializeHandler {
 
     func initializeBuild(
         _ request: InitializeBuildRequest,
-        _ id: RequestID
+        _ id: RequestID,
     ) throws -> (InitializeBuildResponse, InitializedServerConfig) {
         let taskId = TaskId(id: "initializeBuild-\(id.description)")
         connection?.startWorkTask(id: taskId, title: "Indexing: Initializing sourcekit-bazel-bsp")

--- a/Sources/SourceKitBazelBSP/Server/MessageHandler/BSPRequestHandler.swift
+++ b/Sources/SourceKitBazelBSP/Server/MessageHandler/BSPRequestHandler.swift
@@ -20,7 +20,11 @@
 import Foundation
 import LanguageServerProtocol
 
-typealias BSPRequestHandler<Request: RequestType> = ((Request, RequestID) throws -> Request.Response)
+typealias BSPRequestHandlerCompletion<Request: RequestType> = ((Result<Request.Response, Error>) -> Void)
+typealias BSPRequestHandler<Request: RequestType> = (
+    (Request, RequestID, @escaping BSPRequestHandlerCompletion<Request>) -> Void
+)
+typealias BSPSyncRequestHandler<Request: RequestType> = ((Request, RequestID) throws -> Request.Response)
 
 /// A type-erased request handler wrapper to allow for dynamic registration of handlers.
 final class AnyRequestHandler {


### PR DESCRIPTION
This allows requests to return asynchronously if needed. This is because we need the main thread unlocked to be able to receive things like cancelation requests, so we will need certain requests to run in the background. At the moment everything behaves the same, but I'll open follow-up PRs to move things to the background as I understand what SK-LSP does and doesn't execute in parallel.