### PR TITLE
Make the important requests run async

### DIFF
--- a/.bsp/config.json
+++ b/.bsp/config.json
@@ -1,6 +1,6 @@
 {
 	"name": "sourcekit-bazel-bsp",
-	"version": "0.0.5",
+	"version": "0.1.0",
 	"bspVersion": "2.2.0",
 	"languages": [
 		"c",

--- a/Example/.bsp/config.json
+++ b/Example/.bsp/config.json
@@ -1,6 +1,6 @@
 {
 	"name": "sourcekit-bazel-bsp",
-	"version": "0.0.5",
+	"version": "0.1.0",
 	"bspVersion": "2.2.0",
 	"languages": [
 		"c",

--- a/Example/MODULE.bazel
+++ b/Example/MODULE.bazel
@@ -1,22 +1,15 @@
 bazel_dep(
     name = "rules_swift",
-    version = "3.0.2", # 3.1.0 seems to break lldb breakpoints.
+    version = "3.1.2",
     repo_name = "build_bazel_rules_swift",
 )
 
-# We need a commit that has not yet made into a release, so overriding it for now
 bazel_dep(
     name = "rules_apple",
+    version = "4.1.2",
     repo_name = "build_bazel_rules_apple",
 )
-archive_override(
-    module_name = "rules_apple",
-    sha256 = "0abe1a851d65d64a1692bdc95a0649cba4218f0007d36eda030eb6bdfd6b6937",
-    strip_prefix = "rules_apple-a9fcb1c3ae6382534d773d73c035035e9764eadb",
-    url = "https://github.com/bazelbuild/rules_apple/archive/a9fcb1c3ae6382534d773d73c035035e9764eadb.zip",
-)
 
-
-bazel_dep(name = "apple_support", version = "1.22.1", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "apple_support", version = "1.23.1", repo_name = "build_bazel_apple_support")
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.9.3")

--- a/Example/MODULE.bazel.lock
+++ b/Example/MODULE.bazel.lock
@@ -14,8 +14,8 @@
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.21.0/MODULE.bazel": "ac1824ed5edf17dee2fdd4927ada30c9f8c3b520be1b5fd02a5da15bc10bff3e",
     "https://bcr.bazel.build/modules/apple_support/1.21.1/MODULE.bazel": "5809fa3efab15d1f3c3c635af6974044bac8a4919c62238cce06acee8a8c11f1",
-    "https://bcr.bazel.build/modules/apple_support/1.22.1/MODULE.bazel": "90bd1a660590f3ceffbdf524e37483094b29352d85317060b2327fff8f3f4458",
-    "https://bcr.bazel.build/modules/apple_support/1.22.1/source.json": "2bc34da8d0ebc4c4132c8b26db766ca1b86bbcf26dea94b94aa1cd73e2623aeb",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.9.3/MODULE.bazel": "66baf724dbae7aff4787bf2245cc188d50cb08e07789769730151c0943587c14",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.9.3/source.json": "b290debdc0ab191a2a866b5a4e26f042c983026ff58b2e003ea634d838e3b6ae",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -27,11 +27,11 @@
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
     "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
+    "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
-    "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
     "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
@@ -67,7 +67,6 @@
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
-    "https://bcr.bazel.build/modules/protobuf/23.1/MODULE.bazel": "88b393b3eb4101d18129e5db51847cd40a5517a53e81216144a8c32dfeeca52a",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
@@ -81,6 +80,8 @@
     "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.2/MODULE.bazel": "61b3f5d300beda63bed60a9954e88d18bf6b58355bb97ec974453a3af3c5e3e6",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.2/source.json": "8f72c7c365b587110bc7f6c3b551d8976e448e479a1090d161b1f4ecc2f876ad",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
@@ -92,7 +93,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
-    "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.2/source.json": "53fcb09b5816c83ca60d9d7493faf3bfaf410dfc2f15deb52d6ddd146b8d43f0",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
@@ -147,8 +149,8 @@
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/source.json": "c55ed591aa5009401ddf80ded9762ac32c358d2517ee7820be981e2de9756cf3",
     "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
     "https://bcr.bazel.build/modules/rules_swift/2.4.0/MODULE.bazel": "1639617eb1ede28d774d967a738b4a68b0accb40650beadb57c21846beab5efd",
-    "https://bcr.bazel.build/modules/rules_swift/3.0.2/MODULE.bazel": "1d05ce2a87f1fffc251638696d2266e5c80e343daeea133975126d8de1732f14",
-    "https://bcr.bazel.build/modules/rules_swift/3.0.2/source.json": "9252348dff523d1472d633f5b8040510e2b31161681d5b72cdf9d527895ea66d",
+    "https://bcr.bazel.build/modules/rules_swift/3.1.2/MODULE.bazel": "72c8f5cf9d26427cee6c76c8e3853eb46ce6b0412a081b2b6db6e8ad56267400",
+    "https://bcr.bazel.build/modules/rules_swift/3.1.2/source.json": "e85761f3098a6faf40b8187695e3de6d97944e98abd0d8ce579cb2daf6319a66",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
@@ -161,7 +163,6 @@
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/MODULE.bazel": "75aab2373a4bbe2a1260b9bf2a1ebbdbf872d3bd36f80bff058dccd82e89422f",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/source.json": "5fba48bbe0ba48761f9e9f75f92876cafb5d07c0ce059cc7a8027416de94a05b",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
-    "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
@@ -169,37 +170,6 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
-    "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
-      "general": {
-        "bzlTransitiveDigest": "gv4nokEMGNye4Jvoh7Tw0Lzs63zfklj+n4t0UegI7Ms=",
-        "usagesDigest": "2Syl6xg5PlRgZJHvhnwxR7fjNAae5AAxpdRREl5JlHU=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "local_config_apple_cc_toolchains": {
-            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf_toolchains",
-            "attributes": {}
-          },
-          "local_config_apple_cc": {
-            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "apple_support+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "bazel_tools",
-            "rules_cc",
-            "rules_cc+"
-          ]
-        ]
-      }
-    },
     "@@aspect_bazel_lib+//lib:extensions.bzl%toolchains": {
       "general": {
         "bzlTransitiveDigest": "9QjqMWYK48WT6Vm+j6yMCRzETFbmM1LgJcaXV4qqkPg=",

--- a/Example/README.md
+++ b/Example/README.md
@@ -13,7 +13,7 @@ This is a simple **iOS** app that lets you see sourcekit-bazel-bsp in action. Th
 - Reload your workspace (`Cmd+Shift+P -> Reload Window`)
 - Open a Swift file to load the extension. It has to be a Swift file; as of writing this will not work if you open a Objective-C file (but they will work fine after the extension is loaded).
 
-After performing these steps, you should already be able to see the basic indexing features in action. It may take a minute or two the first time as the tool currently builds the entire project, but you can see the progress at the bottom of the IDE. You should also be able to see a new `SourceKit Language Server` option on the `Output` tab that shows sourcekit-lsp's internal logs, and after modifying a file for the first time an additional `SourceKit-LSP: Indexing` tab will pop up containing more detailed logs from both tools.
+After performing these steps, you should already be able to see the basic indexing features in action. It may take a minute or two the first time, but you can see the progress at the bottom of the IDE. You should also be able to see a new `SourceKit Language Server` option on the `Output` tab that shows sourcekit-lsp's internal logs, and after modifying a file for the first time an additional `SourceKit-LSP: Indexing` tab will pop up containing more detailed logs from both tools.
 
 ## Building and Testing
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,13 +1,13 @@
 module(
     name = "sourcekit_bazel_bsp",
-    version = "0.0.5",
+    version = "0.1.0",
     compatibility_level = 0,
 )
 
-bazel_dep(name = "rules_swift", version = "3.1.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_swift", version = "3.1.2", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "rules_swift_package_manager", version = "1.3.0")
 bazel_dep(name = "rules_apple", version = "4.1.2", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "apple_support", version = "1.22.1", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "apple_support", version = "1.23.1", repo_name = "build_bazel_apple_support")
 
 swift_deps = use_extension(
     "@rules_swift_package_manager//:extensions.bzl",

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/sourcekit-lsp",
-            revision: "6022af05e92b1fb9e3e17a09753d6434d8f0dc9b"
+            revision: "1aae2a4c329035163db85d64ae7bc81ee80aaa3c"
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetDiscoverer.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetDiscoverer.swift
@@ -40,7 +40,7 @@ public enum BazelTargetDiscoverer {
 
         let cmd = "\(bazelWrapper) query '\(query)' --output label"
 
-        let output = try commandRunner.run(cmd)
+        let output: String = try commandRunner.run(cmd)
 
         let discoveredTargets =
             output

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetDiscoverer.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetDiscoverer.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-// MARK: - Logger
-
-private let logger = makeFileLevelBSPLogger()
-
 public enum BazelTargetDiscovererError: LocalizedError, Equatable {
     case noTargetsDiscovered
 
@@ -30,8 +26,6 @@ public enum BazelTargetDiscoverer {
         commandRunner: CommandRunner? = nil
     ) throws -> [String] {
         let commandRunner = commandRunner ?? ShellCommandRunner()
-
-        logger.info("Discovering targets for rules: \(rules.map { $0.rawValue }.joined(separator: ", "))")
 
         let query = rules.map {
             "kind(\($0.rawValue), ...)"

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetDiscoverer.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetDiscoverer.swift
@@ -44,7 +44,6 @@ public enum BazelTargetDiscoverer {
             .filter { !$0.isEmpty }
 
         if discoveredTargets.isEmpty {
-            logger.error("No targets discovered!")
             throw BazelTargetDiscovererError.noTargetsDiscovered
         }
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BuildTargetsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BuildTargetsHandler.swift
@@ -41,11 +41,11 @@ final class BuildTargetsHandler {
         _ id: RequestID
     ) throws -> WorkspaceBuildTargetsResponse {
         let taskId = TaskId(id: "buildTargets-\(id.description)")
-        connection?.startWorkTask(id: taskId, title: "Indexing: Processing build graph")
+        connection?.startWorkTask(id: taskId, title: "sourcekit-bazel-bsp: Processing updates to the build graph...")
         do {
-            targetStore.stateLock.lock()
-            let result = try targetStore.fetchTargets()
-            targetStore.stateLock.unlock()
+            let result = try targetStore.stateLock.withLockUnchecked {
+                return try targetStore.fetchTargets()
+            }
             logger.debug("Found \(result.count) targets")
             logger.logFullObjectInMultipleLogMessages(
                 level: .debug,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BuildTargetsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BuildTargetsHandler.swift
@@ -43,7 +43,9 @@ final class BuildTargetsHandler {
         let taskId = TaskId(id: "buildTargets-\(id.description)")
         connection?.startWorkTask(id: taskId, title: "Indexing: Processing build graph")
         do {
+            targetStore.stateLock.lock()
             let result = try targetStore.fetchTargets()
+            targetStore.stateLock.unlock()
             logger.debug("Found \(result.count) targets")
             logger.logFullObjectInMultipleLogMessages(
                 level: .debug,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/DidInitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/DidInitializeHandler.swift
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import Foundation
+import LanguageServerProtocol
+
+private let logger = makeFileLevelBSPLogger()
+
+/// Handles the `build/initialized` notification.
+///
+/// This is called right after returning from the `initialize` request.
+/// We use this to warm-up the bazel cache for our special output bases.
+final class DidInitializeHandler: @unchecked Sendable {
+
+    private let initializedConfig: InitializedServerConfig
+    private let commandRunner: CommandRunner
+
+    init(
+        initializedConfig: InitializedServerConfig,
+        commandRunner: CommandRunner = ShellCommandRunner(),
+    ) {
+        self.initializedConfig = initializedConfig
+        self.commandRunner = commandRunner
+    }
+
+    func onDidInitialize(_ notification: OnBuildInitializedNotification) throws {
+        // Warm-up our special output bases.
+        guard let targetToUse = initializedConfig.baseConfig.targets.first else {
+            return
+        }
+        logger.info("Warming up output bases with \(targetToUse)")
+        let build: RunningProcess? = try? commandRunner.bazelIndexAction(
+            baseConfig: initializedConfig.baseConfig,
+            outputBase: initializedConfig.outputBase,
+            cmd: "query \(targetToUse)",
+            rootUri: initializedConfig.rootUri
+        )
+        build?.setTerminationHandler { [weak self] code in
+            logger.info("Finished warming up the build output base! (status code: \(code))")
+            guard let self = self else {
+                return
+            }
+            guard initializedConfig.aqueryOutputBase != initializedConfig.outputBase else {
+                return
+            }
+            // FIXME: We have to warm up the aqueries *after* the build, otherwise we can run
+            // into some weird race condition with rules_swift I'm not sure about.
+            let aquery: RunningProcess? = try? commandRunner.bazelIndexAction(
+                baseConfig: initializedConfig.baseConfig,
+                outputBase: initializedConfig.aqueryOutputBase,
+                cmd: "query \(targetToUse)",
+                rootUri: initializedConfig.rootUri
+            )
+            aquery?.setTerminationHandler { code in
+                logger.info("Finished warming up the aquery output base! (status code: \(code))")
+            }
+        }
+    }
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -21,7 +21,7 @@ import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
 
-package let sourcekitBazelBSPVersion = "0.0.5"
+package let sourcekitBazelBSPVersion = "0.1.0"
 private let logger = makeFileLevelBSPLogger()
 
 enum InitializeHandlerError: Error, LocalizedError {
@@ -61,7 +61,7 @@ final class InitializeHandler {
         _ id: RequestID,
     ) throws -> (InitializeBuildResponse, InitializedServerConfig) {
         let taskId = TaskId(id: "initializeBuild-\(id.description)")
-        connection?.startWorkTask(id: taskId, title: "Indexing: Initializing sourcekit-bazel-bsp")
+        connection?.startWorkTask(id: taskId, title: "sourcekit-bazel-bsp: Initializing...")
         do {
             let initializedConfig = try makeInitializedConfig(fromRequest: request, baseConfig: baseConfig)
             let result = buildResponse(fromRequest: request, and: initializedConfig)

--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -32,10 +32,6 @@ final class PrepareHandler {
     private let commandRunner: CommandRunner
     private weak var connection: LSPConnection?
 
-    // SourceKit-LSP sometimes re-shuffles tasks mid-execution, so we need to
-    // cache things from our side as well to prevent duplicated builds.
-    private var buildCache: Set<URI> = []
-
     init(
         initializedConfig: InitializedServerConfig,
         targetStore: BazelTargetStore,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetAquerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetAquerier.swift
@@ -66,8 +66,13 @@ final class BazelTargetAquerier {
             return cached
         }
 
-        // Run the aquery on the special index output base since that's where we will build at.
-        let output: Data = try commandRunner.bazelIndexAction(initializedConfig: config, cmd: cmd)
+        // Run the aquery with the special index flags since that's what we will build with.
+        let output: Data = try commandRunner.bazelIndexAction(
+            baseConfig: config.baseConfig,
+            outputBase: config.aqueryOutputBase,
+            cmd: cmd,
+            rootUri: config.rootUri
+        )
 
         let parsedOutput = try BazelProtobufBindings.parseActionGraph(data: output)
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/CompilerArgumentsProcessor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/CompilerArgumentsProcessor.swift
@@ -71,9 +71,30 @@ enum CompilerArgumentsProcessor {
     ) -> [String] {
 
         let devDir = initializedConfig.devDir
-        let outputPath = initializedConfig.outputPath
         let rootUri = initializedConfig.rootUri
-        let outputBase = initializedConfig.outputBase
+
+        // We ran the aquery on the aquery output base, but we need this
+        // to reflect the data of the real build output base.
+        let outputPath: String = {
+            let base: String = initializedConfig.outputPath
+            guard initializedConfig.aqueryOutputBase != initializedConfig.outputBase else {
+                return base
+            }
+            return base.replacingOccurrences(
+                of: initializedConfig.aqueryOutputBase,
+                with: initializedConfig.outputBase
+            )
+        }()
+        let outputBase = {
+            let base: String = initializedConfig.outputBase
+            guard initializedConfig.aqueryOutputBase != initializedConfig.outputBase else {
+                return base
+            }
+            return base.replacingOccurrences(
+                of: initializedConfig.aqueryOutputBase,
+                with: initializedConfig.outputBase
+            )
+        }()
 
         var compilerArguments: [String] = []
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
@@ -63,9 +63,11 @@ final class SKOptionsHandler: InvalidatedTargetObserver {
     }
 
     func handle(request: TextDocumentSourceKitOptionsRequest) throws -> TextDocumentSourceKitOptionsResponse? {
+        targetStore.stateLock.lock()
         let targetUri = request.target.uri
         let (bazelTarget, platform) = try targetStore.platformBuildLabel(forBSPURI: targetUri)
         let underlyingLibrary = try targetStore.bazelTargetLabel(forBSPURI: targetUri)
+        targetStore.stateLock.unlock()
 
         logger.info(
             "Fetching SKOptions for \(targetUri.stringValue), target: \(bazelTarget), language: \(request.language)"

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
@@ -21,6 +21,8 @@ import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
 
+import struct os.OSAllocatedUnfairLock
+
 private let logger = makeFileLevelBSPLogger()
 
 /// Handles the `textDocument/sourceKitOptions` request.
@@ -51,7 +53,7 @@ final class SKOptionsHandler: InvalidatedTargetObserver {
         _ id: RequestID
     ) throws -> TextDocumentSourceKitOptionsResponse? {
         let taskId = TaskId(id: "getSKOptions-\(id.description)")
-        connection?.startWorkTask(id: taskId, title: "Indexing: Getting compiler arguments")
+        connection?.startWorkTask(id: taskId, title: "sourcekit-bazel-bsp: Fetching compiler arguments...")
         do {
             let result = try handle(request: request)
             connection?.finishTask(id: taskId, status: .ok)
@@ -63,11 +65,12 @@ final class SKOptionsHandler: InvalidatedTargetObserver {
     }
 
     func handle(request: TextDocumentSourceKitOptionsRequest) throws -> TextDocumentSourceKitOptionsResponse? {
-        targetStore.stateLock.lock()
-        let targetUri = request.target.uri
-        let (bazelTarget, platform) = try targetStore.platformBuildLabel(forBSPURI: targetUri)
-        let underlyingLibrary = try targetStore.bazelTargetLabel(forBSPURI: targetUri)
-        targetStore.stateLock.unlock()
+        let (targetUri, bazelTarget, platform, underlyingLibrary) = try targetStore.stateLock.withLockUnchecked {
+            let targetUri = request.target.uri
+            let (bazelTarget, platform) = try targetStore.platformBuildLabel(forBSPURI: targetUri)
+            let underlyingLibrary = try targetStore.bazelTargetLabel(forBSPURI: targetUri)
+            return (targetUri, bazelTarget, platform, underlyingLibrary)
+        }
 
         logger.info(
             "Fetching SKOptions for \(targetUri.stringValue), target: \(bazelTarget), language: \(request.language)"
@@ -95,9 +98,11 @@ final class SKOptionsHandler: InvalidatedTargetObserver {
     // MARK: - InvalidatedTargetObserver
 
     func invalidate(targets: [InvalidatedTarget]) throws {
-        // Only clear cache if at least one file was created or deleted
-        if targets.contains(where: { $0.kind == .created || $0.kind == .deleted }) {
-            extractor.clearCache()
+        // Only clear the cache if at least one file was created or deleted.
+        // Otherwise, the compiler args are bound to be the same.
+        guard targets.contains(where: { $0.kind == .created || $0.kind == .deleted }) else {
+            return
         }
+        extractor.clearCache()
     }
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
@@ -43,14 +43,15 @@ final class TargetSourcesHandler {
         let targets = request.targets
         logger.info("Fetching sources for \(targets.count) targets")
 
-        targetStore.stateLock.lock()
-        var srcs: [SourcesItem] = []
-        for target in targets {
-            let targetSrcs = try targetStore.bazelTargetSrcs(forBSPURI: target.uri)
-            let sources = convertToSourceItems(targetSrcs)
-            srcs.append(SourcesItem(target: target, sources: sources))
+        let srcs: [SourcesItem] = try targetStore.stateLock.withLockUnchecked {
+            var srcs: [SourcesItem] = []
+            for target in targets {
+                let targetSrcs = try targetStore.bazelTargetSrcs(forBSPURI: target.uri)
+                let sources = convertToSourceItems(targetSrcs)
+                srcs.append(SourcesItem(target: target, sources: sources))
+            }
+            return srcs
         }
-        targetStore.stateLock.unlock()
 
         let count = srcs.reduce(0) { $0 + $1.sources.count }
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
@@ -43,12 +43,14 @@ final class TargetSourcesHandler {
         let targets = request.targets
         logger.info("Fetching sources for \(targets.count) targets")
 
+        targetStore.stateLock.lock()
         var srcs: [SourcesItem] = []
         for target in targets {
             let targetSrcs = try targetStore.bazelTargetSrcs(forBSPURI: target.uri)
             let sources = convertToSourceItems(targetSrcs)
             srcs.append(SourcesItem(target: target, sources: sources))
         }
+        targetStore.stateLock.unlock()
 
         let count = srcs.reduce(0) { $0 + $1.sources.count }
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/WaitUpdatesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WaitUpdatesHandler.swift
@@ -42,8 +42,8 @@ final class WaitUpdatesHandler: @unchecked Sendable {
         _ id: RequestID
     ) throws -> VoidResponse {
         // If we can acquire the lock, then no updates are pending.
-        targetStore.stateLock.lock()
-        targetStore.stateLock.unlock()
-        return VoidResponse()
+        return targetStore.stateLock.withLockUnchecked {
+            return VoidResponse()
+        }
     }
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/WaitUpdatesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WaitUpdatesHandler.swift
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import Foundation
+import LanguageServerProtocol
+
+/// Handles the `waitForBuildSystemUpdates` request.
+///
+/// This just checks if the target store is processing updates.
+final class WaitUpdatesHandler: @unchecked Sendable {
+
+    private let targetStore: BazelTargetStore
+    private weak var connection: LSPConnection?
+
+    init(
+        targetStore: BazelTargetStore,
+        connection: LSPConnection? = nil
+    ) {
+        self.targetStore = targetStore
+        self.connection = connection
+    }
+
+    func workspaceWaitForBuildSystemUpdates(
+        _ request: WorkspaceWaitForBuildSystemUpdatesRequest,
+        _ id: RequestID
+    ) throws -> VoidResponse {
+        // If we can acquire the lock, then no updates are pending.
+        targetStore.stateLock.lock()
+        targetStore.stateLock.unlock()
+        return VoidResponse()
+    }
+}

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -30,18 +30,21 @@ package struct BaseServerConfig: Equatable {
     let indexFlags: [String]
     let buildTestSuffix: String
     let filesToWatch: String?
+    let useSeparateOutputBaseForAquery: Bool
 
     package init(
         bazelWrapper: String,
         targets: [String],
         indexFlags: [String],
         buildTestSuffix: String,
-        filesToWatch: String?
+        filesToWatch: String?,
+        useSeparateOutputBaseForAquery: Bool = false
     ) {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
         self.indexFlags = indexFlags
         self.buildTestSuffix = buildTestSuffix
         self.filesToWatch = filesToWatch
+        self.useSeparateOutputBaseForAquery = useSeparateOutputBaseForAquery
     }
 }

--- a/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
@@ -36,4 +36,13 @@ struct InitializedServerConfig: Equatable {
     var indexStorePath: String {
         outputPath + "/_global_index_store"
     }
+
+    // We currently use a third output base for aquerying
+    // to prevent extracting compiler args from being blocked by index builds.
+    var aqueryOutputBase: String {
+        guard baseConfig.useSeparateOutputBaseForAquery else {
+            return outputBase
+        }
+        return outputBase + "-aq"
+    }
 }

--- a/Sources/SourceKitBazelBSP/Server/MessageHandler/AsyncMessageHandler.swift
+++ b/Sources/SourceKitBazelBSP/Server/MessageHandler/AsyncMessageHandler.swift
@@ -24,9 +24,14 @@ import LanguageServerProtocol
 /// Base object that forwards BSP messages to a separate queue.
 /// This exists simply to make sure we can continue to receive messages
 /// as we process them. Otherwise, each request would require its own queue.
+/// Messages can also be processed concurrently.
 final class AsyncMessageHandler: MessageHandler {
 
-    private let queue = DispatchQueue(label: "AsyncMessageHandler", qos: .userInitiated)
+    private let queue = DispatchQueue(
+        label: "AsyncMessageHandler",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
     private let messageHandler: MessageHandler
 
     init(wrapping handler: MessageHandler) {

--- a/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
+++ b/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
@@ -53,12 +53,10 @@ package final class SourceKitBazelBSPServer {
         initializedConfig: InitializedServerConfig,
         connection: JSONRPCConnection
     ) {
-        // First, deal with the no-op handlers we cannot or do not want to handle directly.
-        registry.register(notificationHandler: { (_: OnBuildInitializedNotification) in
-            // no-op
-        })
+        // build/initialized
+        let didInitializeHandler = DidInitializeHandler(initializedConfig: initializedConfig)
+        registry.register(notificationHandler: didInitializeHandler.onDidInitialize)
 
-        // Then, register the things we are interested in.
         // workspace/buildTargets
         let targetStore = BazelTargetStoreImpl(initializedConfig: initializedConfig)
         let buildTargetsHandler = BuildTargetsHandler(targetStore: targetStore, connection: connection)

--- a/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
+++ b/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
@@ -57,16 +57,16 @@ package final class SourceKitBazelBSPServer {
         registry.register(notificationHandler: { (_: OnBuildInitializedNotification) in
             // no-op
         })
-        registry.register(syncRequestHandler: { (_: WorkspaceWaitForBuildSystemUpdatesRequest, _: RequestID) in
-            // FIXME: no-op, no special handling since the code today is not async, but I might be wrong here.
-            VoidResponse()
-        })
 
         // Then, register the things we are interested in.
         // workspace/buildTargets
         let targetStore = BazelTargetStoreImpl(initializedConfig: initializedConfig)
         let buildTargetsHandler = BuildTargetsHandler(targetStore: targetStore, connection: connection)
         registry.register(syncRequestHandler: buildTargetsHandler.workspaceBuildTargets)
+
+        // workspace/waitForBuildSystemUpdates
+        let waitUpdatesHandler = WaitUpdatesHandler(targetStore: targetStore, connection: connection)
+        registry.register(syncRequestHandler: waitUpdatesHandler.workspaceWaitForBuildSystemUpdates)
 
         // buildTarget/sources
         let targetSourcesHandler = TargetSourcesHandler(initializedConfig: initializedConfig, targetStore: targetStore)

--- a/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
+++ b/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
@@ -91,7 +91,7 @@ package final class SourceKitBazelBSPServer {
         // OnWatchedFilesDidChangeNotification
         let watchedFileChangeHandler = WatchedFileChangeHandler(
             targetStore: targetStore,
-            observers: [prepareHandler, skOptionsHandler],
+            observers: [skOptionsHandler],
             connection: connection
         )
         registry.register(notificationHandler: watchedFileChangeHandler.onWatchedFilesDidChange)

--- a/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
+++ b/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
@@ -86,7 +86,7 @@ package final class SourceKitBazelBSPServer {
             targetStore: targetStore,
             connection: connection
         )
-        registry.register(syncRequestHandler: prepareHandler.prepareTarget)
+        registry.register(requestHandler: prepareHandler.prepareTarget)
 
         // OnWatchedFilesDidChangeNotification
         let watchedFileChangeHandler = WatchedFileChangeHandler(

--- a/Sources/SourceKitBazelBSP/SharedUtils/Shell/CommandRunner.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/Shell/CommandRunner.swift
@@ -59,25 +59,6 @@ extension CommandRunner {
     }
 
     /// A regular bazel command, but at this BSP's special output base and taking into account the special index flags.
-    func bazelIndexAction(initializedConfig: InitializedServerConfig, cmd: String) throws -> RunningProcess {
-        return try bazelIndexAction(
-            baseConfig: initializedConfig.baseConfig,
-            outputBase: initializedConfig.outputBase,
-            cmd: cmd,
-            rootUri: initializedConfig.rootUri
-        )
-    }
-
-    /// A regular bazel command, but at this BSP's special output base and taking into account the special index flags.
-    func bazelIndexAction<T: DataConvertible>(initializedConfig: InitializedServerConfig, cmd: String) throws -> T {
-        let process = try bazelIndexAction(
-            initializedConfig: initializedConfig,
-            cmd: cmd
-        )
-        return try process.output()
-    }
-
-    /// A regular bazel command, but at this BSP's special output base and taking into account the special index flags.
     func bazelIndexAction(
         baseConfig: BaseServerConfig,
         outputBase: String,

--- a/Sources/SourceKitBazelBSP/SharedUtils/Shell/CommandRunner.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/Shell/CommandRunner.swift
@@ -21,7 +21,7 @@ import Foundation
 
 private let logger = makeFileLevelBSPLogger()
 
-public protocol CommandRunner {
+public protocol CommandRunner: Sendable {
     func run(_ cmd: String, cwd: String?, stdout: Pipe, stderr: Pipe) throws -> RunningProcess
 }
 

--- a/Sources/SourceKitBazelBSP/SharedUtils/Shell/RunningProcess.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/Shell/RunningProcess.swift
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+private let logger = makeFileLevelBSPLogger()
+
+public protocol CommandLineProcess: Sendable {
+    func waitUntilExit()
+    func terminate()
+    var terminationStatus: Int32 { get }
+}
+
+extension Process: CommandLineProcess {}
+
+public struct RunningProcess: Sendable {
+    let cmd: String
+    let stdout: Pipe
+    let stderr: Pipe
+    let wrappedProcess: CommandLineProcess
+
+    public init(cmd: String, stdout: Pipe, stderr: Pipe, wrappedProcess: CommandLineProcess) {
+        self.cmd = cmd
+        self.stdout = stdout
+        self.stderr = stderr
+        self.wrappedProcess = wrappedProcess
+    }
+
+    public func output<T: DataConvertible>() throws -> T {
+        // Drain stdout/err first to avoid deadlocking when the output is buffered.
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+
+        wrappedProcess.waitUntilExit()
+
+        guard wrappedProcess.terminationStatus == 0 else {
+            logger.debug("Command failed: \(cmd)")
+            let stderrString: String = String(data: stderrData, encoding: .utf8) ?? "(no stderr)"
+            throw ShellCommandRunnerError.failed(cmd, stderrString)
+        }
+
+        return T.convert(from: data)
+    }
+
+    public func terminate() {
+        wrappedProcess.terminate()
+    }
+}

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -31,7 +31,7 @@ struct Serve: ParsableCommand {
     @Option(
         parsing: .singleValue,
         help:
-            "The *top level* Bazel application or test targets that this should serve a BSP for. Can be specified multiple times. If not specified, the server will try to discover top-leveltargets automatically."
+            "The *top level* Bazel application or test target that this should serve a BSP for. Can be specified multiple times. It's best to keep this list small if possible for performance reasons. If not specified, the server will try to discover top-level targets automatically."
     )
     var target: [String] = []
 
@@ -44,9 +44,16 @@ struct Serve: ParsableCommand {
 
     @Option(
         help:
-            "The expected suffix for build_test targets. Defaults to '_skbsp'."
+            "The expected suffix for build_test targets."
     )
     var buildTestSuffix: String = "_skbsp"
+
+    // FIXME: This should be enabled by default, but I ran into some weird race condition issues with rules_swift I'm not sure about.
+    @Flag(
+        help:
+            "Whether to use a separate output base for compiler arguments requests. This greatly increases the performance of the server at the cost of more disk usage."
+    )
+    var separateAqueryOutput: Bool = false
 
     @Option(help: "Comma separated list of file globs to watch for changes.")
     var filesToWatch: String?
@@ -60,6 +67,9 @@ struct Serve: ParsableCommand {
             if !target.isEmpty {
                 return target
             }
+            logger.warning(
+                "No targets specified (--target)! Will now try to discover them. This can cause the BSP to perform poorly if we find too many targets. Prefer using --target explicitly if possible."
+            )
             return try BazelTargetDiscoverer.discoverTargets(
                 bazelWrapper: bazelWrapper
             )
@@ -70,7 +80,8 @@ struct Serve: ParsableCommand {
             targets: targets,
             indexFlags: indexFlag.map { "--" + $0 },
             buildTestSuffix: buildTestSuffix,
-            filesToWatch: filesToWatch
+            filesToWatch: filesToWatch,
+            useSeparateOutputBaseForAquery: separateAqueryOutput
         )
         let server = SourceKitBazelBSPServer(baseConfig: config)
         server.run()

--- a/Tests/SourceKitBazelBSPTests/BSPMessageHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BSPMessageHandlerTests.swift
@@ -91,7 +91,8 @@ struct BSPMessageHandlerTests {
         let semaphore = DispatchSemaphore(value: 0)
         let handler = BSPMessageHandler()
         handler.register(requestHandler: { (request: BuildTargetSourcesRequest, id, completion) in
-            queue.asyncAfter(deadline: .now() + 1) {
+            nonisolated(unsafe) let completion = completion
+            queue.async {
                 completion(.success(BuildTargetSourcesResponse(items: [])))
             }
         })
@@ -106,7 +107,7 @@ struct BSPMessageHandlerTests {
             semaphore.signal()
         }
 
-        semaphore.wait()
+        #expect(semaphore.wait(timeout: .now() + 1) == .success)
 
         let result = try #require(receivedResponse)
         switch result {

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -385,5 +385,4 @@ let expectedObjCResult: [String] = [
     "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/_global_index_store",
     "-working-directory",
     "/Users/user/Documents/demo-ios-project",
-
 ]

--- a/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetStoreFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetStoreFake.swift
@@ -21,9 +21,12 @@ import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
 
+import struct os.OSAllocatedUnfairLock
+
 @testable import SourceKitBazelBSP
 
 final class BazelTargetStoreFake: BazelTargetStore {
+    let stateLock = OSAllocatedUnfairLock()
     var clearCacheCalled = false
     var fetchTargetsCalled = false
     var fetchTargetsError: Error?

--- a/Tests/SourceKitBazelBSPTests/Fakes/CommandRunnerFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/CommandRunnerFake.swift
@@ -31,7 +31,7 @@ enum CommandRunnerFakeError: Error, LocalizedError {
     }
 }
 
-final class CommandRunnerFake: CommandRunner {
+final class CommandRunnerFake: CommandRunner, @unchecked Sendable {
 
     private(set) var commands: [(command: String, cwd: String?)] = []
     private var responses: [String: Data] = [:]
@@ -80,5 +80,9 @@ final class CommandLineProcessFake: CommandLineProcess {
 
     func terminate() {
         // no-op
+    }
+
+    func setTerminationHandler(_ handler: @escaping @Sendable (Int32) -> Void) {
+        handler(terminationStatus)
     }
 }

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -60,7 +60,13 @@ struct PrepareHandlerTests {
             connection: connection
         )
 
-        try handler.build(bazelLabels: baseConfig.targets)
+        let semaphore = DispatchSemaphore(value: 0)
+        try handler.build(bazelLabels: baseConfig.targets, id: RequestID.number(1)) { error in
+            #expect(error == nil)
+            semaphore.signal()
+        }
+
+        #expect(semaphore.wait(timeout: .now() + 1) == .success)
 
         let ranCommands = commandRunner.commands
         #expect(ranCommands.count == 1)
@@ -99,7 +105,13 @@ struct PrepareHandlerTests {
             connection: connection
         )
 
-        try handler.build(bazelLabels: baseConfig.targets)
+        let semaphore = DispatchSemaphore(value: 0)
+        try handler.build(bazelLabels: baseConfig.targets, id: RequestID.number(1)) { error in
+            #expect(error == nil)
+            semaphore.signal()
+        }
+
+        #expect(semaphore.wait(timeout: .now() + 1) == .success)
 
         let ranCommands = commandRunner.commands
         #expect(ranCommands.count == 1)

--- a/rules/bsp_config.json.tpl
+++ b/rules/bsp_config.json.tpl
@@ -1,6 +1,6 @@
 {
 	"name": "sourcekit-bazel-bsp",
-	"version": "0.0.5",
+	"version": "0.1.0",
 	"bspVersion": "2.2.0",
 	"languages": [
 		"c",

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -9,10 +9,15 @@ def _setup_sourcekit_bsp_impl(ctx):
         bsp_config_argv.append(target.label)
     bsp_config_argv.append("--bazel-wrapper")
     bsp_config_argv.append(ctx.attr.bazel_wrapper)
+    bsp_config_argv.append("--build-test-suffix")
+    bsp_config_argv.append(ctx.attr.build_test_suffix)
+    bsp_config_argv.append("--separate-aquery-output")
+    bsp_config_argv.append(ctx.attr.separate_aquery_output)
     for index_flag in ctx.attr.index_flags:
         bsp_config_argv.append("--index-flag")
         bsp_config_argv.append(index_flag)
-    for files_to_watch in ctx.attr.files_to_watch:
+    files_to_watch = ','.join(ctx.attr.files_to_watch)
+    if files_to_watch:
         bsp_config_argv.append("--files-to-watch")
         bsp_config_argv.append(files_to_watch)
     ctx.actions.expand_template(
@@ -67,18 +72,28 @@ setup_sourcekit_bsp = rule(
             executable = True,
         ),
         "targets": attr.label_list(
-            doc = "The targets to set up the sourcekit-bazel-bsp for.",
+            doc = "The *top level* Bazel applications or test targets that this should serve a BSP for. It's best to keep this list small if possible for performance reasons. If not specified, the server will try to discover top-level targets automatically",
             mandatory = True,
         ),
         "bazel_wrapper": attr.string(
-            doc = "The bazel wrapper to use.",
+            doc = "The name of the Bazel CLI to invoke (e.g. 'bazelisk').",
             default = "bazel",
         ),
         "index_flags": attr.string_list(
-            doc = "The index flags to use.",
+            doc = "Flags that should be passed to all indexing-related Bazel invocations. Do not include the -- prefix.",
+            default = [],
         ),
         "files_to_watch": attr.string_list(
-            doc = "The files to watch.",
+            doc = "A list of file globs to watch for changes.",
+            default = [],
         ),
+        "build_test_suffix": attr.string(
+            doc = "The expected suffix for build_test targets.",
+            default = "_skbsp",
+        )
+        "separate_aquery_output": attr.bool(
+            doc = "Whether to use a separate output base for compiler arguments requests. This greatly increases the performance of the server at the cost of more disk usage.",
+            default = False,
+        )
     },
 )


### PR DESCRIPTION
A huge PR that reworks most of the requests to support async execution, among other improvements.

- CommandRunner: Now supports returning the base process to support watching commands async.
- BSPMessageHandler: Will now dispatch messages concurrently to the background.
- Added a new `DidInitializeHandler` that attempts to pre-warm the special output bases in advance.
- Added a new `WaitUpdatesHandler` that watches if we're trying to re-build the target cache.
- WatchedFilesHandler will now only notify the LSP if we add or remove files. This should increase performance in most cases. It now also cleans the cache on file deletions.
- Added support for request cancelation for `PrepareHandler`. The handler now also runs the build on the background.
- Re-worked thread-safety in most requests to support async execution.
- Bumped all rules_ and sourcekit-lsp
- Added a note on running custom sourcekit-lsp binaries
- Added a new `--separate-aquery-output` parameter that allows aqueries to run on a third output base, increasing performance at the cost of disk usage (default: false)