### PR TITLE
Disable compiler param file for aquerying compiler args

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -106,7 +106,7 @@ final class BazelTargetCompilerArgsExtractor {
             filteringFor: underlyingLibrary,
             config: config,
             mnemonics: ["SwiftCompile", "ObjcCompile"],
-            additionalFlags: ["--noinclude_artifacts", "--noinclude_aspects"]
+            additionalFlags: ["--noinclude_artifacts", "--noinclude_aspects", "--features=-compiler_param_file"]
         )
 
         // Then, determine the SDK root based on the platform the target is built for

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -60,7 +60,7 @@ struct BazelTargetCompilerArgsExtractorTests {
     func extractsAndProcessesCompilerArguments_complexRealWorldSwiftExample() throws {
         let (extractor, mockRunner, mockRootUri) = Self.makeMockExtractor()
         let expectedAQuery =
-            "bazel --output_base=/private/var/tmp/_bazel_user/hash123 aquery \"mnemonic('ObjcCompile|SwiftCompile', filter(//HelloWorld:HelloWorldLib, deps(//HelloWorld:HelloWorldLib_ios_skbsp)))\" --noinclude_artifacts --noinclude_aspects --output proto"
+            "bazel --output_base=/private/var/tmp/_bazel_user/hash123 aquery \"mnemonic('ObjcCompile|SwiftCompile', filter(//HelloWorld:HelloWorldLib, deps(//HelloWorld:HelloWorldLib_ios_skbsp)))\" --noinclude_artifacts --noinclude_aspects --features=-compiler_param_file --output proto"
         mockRunner.setResponse(for: expectedAQuery, cwd: mockRootUri, response: exampleAqueryOutput)
         let expectedSdkRoot =
             "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
@@ -86,7 +86,7 @@ struct BazelTargetCompilerArgsExtractorTests {
     func extractsAndProcessesCompilerArguments_complexRealWorldObjCExample() throws {
         let (extractor, mockRunner, mockRootUri) = Self.makeMockExtractor()
         let expectedAQuery =
-            "bazel --output_base=/private/var/tmp/_bazel_user/hash123 aquery \"mnemonic('ObjcCompile|SwiftCompile', filter(//HelloWorld:TodoObjCSupport, deps(//HelloWorld:TodoObjCSupport_ios_skbsp)))\" --noinclude_artifacts --noinclude_aspects --output proto"
+            "bazel --output_base=/private/var/tmp/_bazel_user/hash123 aquery \"mnemonic('ObjcCompile|SwiftCompile', filter(//HelloWorld:TodoObjCSupport, deps(//HelloWorld:TodoObjCSupport_ios_skbsp)))\" --noinclude_artifacts --noinclude_aspects --features=-compiler_param_file --output proto"
         mockRunner.setResponse(for: expectedAQuery, cwd: mockRootUri, response: exampleAqueryObjcOutput)
         let expectedSdkRoot =
             "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
@@ -134,7 +134,7 @@ struct BazelTargetCompilerArgsExtractorTests {
     func missingObjCFileReturnsNil() throws {
         let (extractor, mockRunner, mockRootUri) = Self.makeMockExtractor()
         let expectedAQuery =
-            "bazel --output_base=/private/var/tmp/_bazel_user/hash123 aquery \"mnemonic('ObjcCompile|SwiftCompile', filter(//HelloWorld:TodoObjCSupport, deps(//HelloWorld:TodoObjCSupport_ios_skbsp)))\" --noinclude_artifacts --noinclude_aspects --output proto"
+            "bazel --output_base=/private/var/tmp/_bazel_user/hash123 aquery \"mnemonic('ObjcCompile|SwiftCompile', filter(//HelloWorld:TodoObjCSupport, deps(//HelloWorld:TodoObjCSupport_ios_skbsp)))\" --noinclude_artifacts --noinclude_aspects --features=-compiler_param_file --output proto"
         mockRunner.setResponse(for: expectedAQuery, cwd: mockRootUri, response: exampleAqueryOutput)
         let expectedSdkRoot =
             "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
@@ -183,7 +183,7 @@ struct BazelTargetCompilerArgsExtractorTests {
     func missingSwiftModuleReturnsNil() throws {
         let (extractor, mockRunner, mockRootUri) = Self.makeMockExtractor()
         let expectedAQuery =
-            "bazel --output_base=/private/var/tmp/_bazel_user/hash123 aquery \"mnemonic('ObjcCompile|SwiftCompile', filter(//HelloWorld:SomethingElseLib, deps(//HelloWorld:SomethingElseLib_ios_skbsp)))\" --noinclude_artifacts --noinclude_aspects --output proto"
+            "bazel --output_base=/private/var/tmp/_bazel_user/hash123 aquery \"mnemonic('ObjcCompile|SwiftCompile', filter(//HelloWorld:SomethingElseLib, deps(//HelloWorld:SomethingElseLib_ios_skbsp)))\" --noinclude_artifacts --noinclude_aspects --features=-compiler_param_file --output proto"
         mockRunner.setResponse(for: expectedAQuery, cwd: mockRootUri, response: exampleAqueryOutput)
         let expectedSdkRoot =
             "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
@@ -207,7 +207,7 @@ struct BazelTargetCompilerArgsExtractorTests {
     func cachesCompilerArgs() throws {
         let (extractor, mockRunner, mockRootUri) = Self.makeMockExtractor()
         let expectedAQuery =
-            "bazel --output_base=/private/var/tmp/_bazel_user/hash123 aquery \"mnemonic('ObjcCompile|SwiftCompile', filter(//HelloWorld:HelloWorldLib, deps(//HelloWorld:HelloWorldLib_ios_skbsp)))\" --noinclude_artifacts --noinclude_aspects --output proto"
+            "bazel --output_base=/private/var/tmp/_bazel_user/hash123 aquery \"mnemonic('ObjcCompile|SwiftCompile', filter(//HelloWorld:HelloWorldLib, deps(//HelloWorld:HelloWorldLib_ios_skbsp)))\" --noinclude_artifacts --noinclude_aspects --features=-compiler_param_file --output proto"
         mockRunner.setResponse(for: expectedAQuery, cwd: mockRootUri, response: exampleAqueryOutput)
         let expectedSdkRoot =
             "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"


### PR DESCRIPTION
Our codebase utilizes params files (generated via build `--features=compiler_param_file`). Current logic in `CompilerArgumentsProcessor` does not handle files as arguments and therefore, args such as `__BAZEL_XCODE_SDKROOT__`, `__BAZEL_XCODE_DEVELOPER_DIR__`, etc. do not get updated.

Unfortunately for our codebase, turning off the compiler param file entirely is not an option as it leads to `Argument list too long errors` during compilation.

Updating the `aquery` for fetching compiler args to disable this feature.