### PR TITLE
Update compiler working directory to run from execution root

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -100,6 +100,15 @@ final class InitializeHandler {
         )
         logger.debug("outputPath: \(outputPath)")
 
+        // Get the execution root based on the above output base.
+        let executionRoot: String = try commandRunner.bazelIndexAction(
+            baseConfig: baseConfig,
+            outputBase: outputBase,
+            cmd: "info execution_root",
+            rootUri: rootUri
+        )
+        logger.debug("executionRoot: \(executionRoot)")
+
         // Collecting the rest of the env's details
         let devDir: String = try commandRunner.run("xcode-select --print-path")
         let toolchain = try getToolchainPath(with: commandRunner)
@@ -113,7 +122,8 @@ final class InitializeHandler {
             outputBase: outputBase,
             outputPath: outputPath,
             devDir: devDir,
-            devToolchainPath: toolchain
+            devToolchainPath: toolchain,
+            executionRoot: executionRoot
         )
     }
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
@@ -91,7 +91,7 @@ final class SKOptionsHandler: InvalidatedTargetObserver {
         }
         return TextDocumentSourceKitOptionsResponse(
             compilerArguments: args,
-            workingDirectory: initializedConfig.rootUri
+            workingDirectory: initializedConfig.executionRoot
         )
     }
 

--- a/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
@@ -28,6 +28,7 @@ struct InitializedServerConfig: Equatable {
     let outputPath: String
     let devDir: String
     let devToolchainPath: String
+    let executionRoot: String
 
     var indexDatabasePath: String {
         outputPath + "/_global_index_database"

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -32,6 +32,7 @@ struct BazelTargetCompilerArgsExtractorTests {
         let mockRootUri = "/Users/user/Documents/demo-ios-project"
         let mockDevDir = "/Applications/Xcode.app/Contents/Developer"
         let mockOutputPath = "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out"
+        let mockExecRoot = "/private/var/tmp/_bazel_user/hash123/execroot/__main__"
         let mockOutputBase = "/private/var/tmp/_bazel_user/hash123"
         let mockDevToolchainPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
         let config = InitializedServerConfig(
@@ -46,7 +47,8 @@ struct BazelTargetCompilerArgsExtractorTests {
             outputBase: mockOutputBase,
             outputPath: mockOutputPath,
             devDir: mockDevDir,
-            devToolchainPath: mockDevToolchainPath
+            devToolchainPath: mockDevToolchainPath,
+            executionRoot: mockExecRoot
         )
         let extractor = BazelTargetCompilerArgsExtractor(
             commandRunner: mockRunner,

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -41,7 +41,8 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
-        let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/exec"
+        let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main/bazel-out"
+        let executionRoot = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main"
         let devDir = "/Applications/Xcode.app/Contents/Developer"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
@@ -50,6 +51,11 @@ struct InitializeHandlerTests {
             for: "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info output_path --config=index",
             cwd: rootUri,
             response: outputPath
+        )
+        commandRunner.setResponse(
+            for: "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info execution_root --config=index",
+            cwd: rootUri,
+            response: executionRoot
         )
         commandRunner.setResponse(for: "xcode-select --print-path", response: devDir)
         commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
@@ -68,7 +74,8 @@ struct InitializeHandlerTests {
                     outputBase: outputBase + "-sourcekit-bazel-bsp",
                     outputPath: outputPath,
                     devDir: devDir,
-                    devToolchainPath: toolchain
+                    devToolchainPath: toolchain,
+                    executionRoot: executionRoot
                 )
         )
     }
@@ -87,12 +94,18 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
-        let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/exec"
+        let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main/bazel-out"
+        let executionRoot = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
         commandRunner.setResponse(
             for: "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info output_path",
+            cwd: rootUri,
+            response: outputPath
+        )
+        commandRunner.setResponse(
+            for: "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info execution_root",
             cwd: rootUri,
             response: outputPath
         )
@@ -123,13 +136,20 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
-        let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/exec"
+        let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main/bazel-out"
+        let executionRoot = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
         commandRunner.setResponse(
             for:
                 "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info output_path --config=index1 --config=index2",
+            cwd: rootUri,
+            response: outputPath
+        )
+        commandRunner.setResponse(
+            for:
+                "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info execution_root --config=index1 --config=index2",
             cwd: rootUri,
             response: outputPath
         )

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -47,7 +47,8 @@ struct PrepareHandlerTests {
             outputBase: "/tmp/output_base",
             outputPath: "/tmp/output_path",
             devDir: "/Applications/Xcode.app/Contents/Developer",
-            devToolchainPath: "/a/b/XcodeDefault.xctoolchain/"
+            devToolchainPath: "/a/b/XcodeDefault.xctoolchain/",
+            executionRoot: "/tmp/output_path/execoot/_main"
         )
 
         let expectedCommand = "bazel --output_base=/tmp/output_base build //HelloWorld --config=index"
@@ -92,7 +93,8 @@ struct PrepareHandlerTests {
             outputBase: "/tmp/output_base",
             outputPath: "/tmp/output_path",
             devDir: "/Applications/Xcode.app/Contents/Developer",
-            devToolchainPath: "/a/b/XcodeDefault.xctoolchain/"
+            devToolchainPath: "/a/b/XcodeDefault.xctoolchain/",
+            executionRoot: "/tmp/output_path/execroot/_main"
         )
 
         let expectedCommand = "bazel --output_base=/tmp/output_base build //HelloWorld //HelloWorld2 --config=index"


### PR DESCRIPTION
The compiler is currently configured with `rootURI` as the working directory. This is causing `.swiftmodule` files to be generated at the root of our repo as Swift files are indexed since we have explicit modules enabled and do not use global module cache path. 

By updating the working directory to execution root instead, the index file compilation will be more aligned with how compilation works in Bazel.

**Changes**
- Added `executionRoot` to `InitializedServerConfig`
- Added new `aquery info execution_root` call to pass along to `InitializedServerConfig` 
- Updated `SKOptionsHandler.swift` to use `InitializedServerConfig.executionRoot` for the compilation working directory
- Updated tests

**Test**
- All tests passed
- Verified indexing works in the Example project
- Verified changes in our Bazel project, no longer see `.swiftmodule` files generated at root of repo

