### PR TITLE
Fix Bazel integration

### DIFF
--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -13,8 +13,8 @@ def _setup_sourcekit_bsp_impl(ctx):
     bsp_config_argv.append(ctx.attr.build_test_suffix)
     bsp_config_argv.append("--build-test-platform-placeholder")
     bsp_config_argv.append(ctx.attr.build_test_platform_placeholder)
-    bsp_config_argv.append("--separate-aquery-output")
-    bsp_config_argv.append(ctx.attr.separate_aquery_output)
+    if ctx.attr.separate_aquery_output:
+        bsp_config_argv.append("--separate-aquery-output")
     for index_flag in ctx.attr.index_flags:
         bsp_config_argv.append("--index-flag")
         bsp_config_argv.append(index_flag)

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -5,10 +5,15 @@ set -euo pipefail
 sourcekit_bazel_bsp_path="%sourcekit_bazel_bsp_path%"
 bsp_config_path="%bsp_config_path%"
 
-mkdir -p "$BUILD_WORKSPACE_DIRECTORY/.bsp"
+bsp_folder_path="$BUILD_WORKSPACE_DIRECTORY/.bsp"
 
-cp "${bsp_config_path}" "$BUILD_WORKSPACE_DIRECTORY/.bsp/config.json"
-cp "${sourcekit_bazel_bsp_path}" "$BUILD_WORKSPACE_DIRECTORY/.bsp/sourcekit-bazel-bsp"
+mkdir -p "$bsp_folder_path"
 
-chmod +w "$BUILD_WORKSPACE_DIRECTORY/.bsp/config.json"
-chmod +w "$BUILD_WORKSPACE_DIRECTORY/.bsp/sourcekit-bazel-bsp"
+target_bsp_config_path="$bsp_folder_path/config.json"
+target_sourcekit_bazel_bsp_path="$bsp_folder_path/sourcekit-bazel-bsp"
+
+cp "$bsp_config_path" "$target_bsp_config_path"
+cp "$sourcekit_bazel_bsp_path" "$target_sourcekit_bazel_bsp_path"
+
+chmod +w "$target_bsp_config_path"
+chmod +w "$target_sourcekit_bazel_bsp_path"

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -5,5 +5,10 @@ set -euo pipefail
 sourcekit_bazel_bsp_path="%sourcekit_bazel_bsp_path%"
 bsp_config_path="%bsp_config_path%"
 
+mkdir -p "$BUILD_WORKSPACE_DIRECTORY/.bsp"
+
 cp "${bsp_config_path}" "$BUILD_WORKSPACE_DIRECTORY/.bsp/config.json"
 cp "${sourcekit_bazel_bsp_path}" "$BUILD_WORKSPACE_DIRECTORY/.bsp/sourcekit-bazel-bsp"
+
+chmod +w "$BUILD_WORKSPACE_DIRECTORY/.bsp/config.json"
+chmod +w "$BUILD_WORKSPACE_DIRECTORY/.bsp/sourcekit-bazel-bsp"


### PR DESCRIPTION
The Bazel integration had some minor issues when used:
- If set up using Bazel, the argument would look like
	```bazel
	sourcekit-bazel-bsp serve ... --separate-aquery-output False ...
	```
    Which Swift Argument Parser didn't like, as `--separate-aquery-output` doesn't take any value.
- Running `setup_source_bsp` would not creating the `.bsp` folder if it didn't exist before, and since they're created read-only rerunning the command would fail to overwrite the files