### PR TITLE
Support for large stdout/stderr data in RunningProcess

### DIFF
--- a/Sources/SourceKitBazelBSP/SharedUtils/Shell/CommandRunner.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/Shell/CommandRunner.swift
@@ -30,7 +30,7 @@ extension CommandRunner {
         _ cmd: String,
         cwd: String? = nil,
         stdout: Pipe = Pipe(),
-        stderr: Pipe = Pipe()
+        stderr: Pipe = Pipe(),
     ) throws -> RunningProcess {
         return try run(cmd, cwd: cwd, stdout: stdout, stderr: stderr)
     }
@@ -39,7 +39,7 @@ extension CommandRunner {
         _ cmd: String,
         cwd: String? = nil,
         stdout: Pipe = Pipe(),
-        stderr: Pipe = Pipe()
+        stderr: Pipe = Pipe(),
     ) throws -> T {
         let process = try run(cmd, cwd: cwd, stdout: stdout, stderr: stderr)
         return try process.output()


### PR DESCRIPTION
The existing `RunningProcess` class is using `readDataToEndOfFile()` for reading stdout/stderr. `readDataToEndOfFile()` has size limitations where it will read available data synchronously up to the end of file **or** maximum number of bytes. https://developer.apple.com/documentation/foundation/filehandle/readdatatoendoffile()

We currently use Pipe for stderr and stdout which limits us to a pipe buffer of 64KiB. Due to the size constraint, processing aqueries with the current logic for large codebases is not scalable because we need to continously read stdout/stderr until we reach EOF. This is particularly an issue when we migrate to a single aquery for all targets and is causing hangs/issues because we are unable to process incomplete data. 

To mitigate this, I am migrating the `RunningProcess` to utilize `readabilityHandler` to handle continuously reading stdout/stderr data until process is finished. https://developer.apple.com/documentation/foundation/filehandle/readabilityhandler