### PR TITLE
Support --top-level-rule flag to customize the top level rules used for target discovery.

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
@@ -18,7 +18,7 @@
 // under the License.
 
 // The list of **top-level rules** we know how to process in the BSP.
-public enum TopLevelRuleType: String, CaseIterable {
+public enum TopLevelRuleType: String, CaseIterable, Sendable {
     case iosApplication = "ios_application"
     case iosUnitTest = "ios_unit_test"
     case iosUiTest = "ios_ui_test"

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -24,7 +24,7 @@ import Foundation
 /// Used to bootstrap the connection to sourcekit-lsp, so that later we can create the
 /// more complete `InitializedServerConfig` struct containing all information
 /// needed to operate the server.
-package struct BaseServerConfig: Equatable {
+package struct BaseServerConfig: Equatable, Sendable {
     let bazelWrapper: String
     let targets: [String]
     let indexFlags: [String]
@@ -32,6 +32,7 @@ package struct BaseServerConfig: Equatable {
     let buildTestPlatformPlaceholder: String
     let filesToWatch: String?
     let useSeparateOutputBaseForAquery: Bool
+    let topLevelRules: [TopLevelRuleType]?
 
     package init(
         bazelWrapper: String,
@@ -40,7 +41,8 @@ package struct BaseServerConfig: Equatable {
         buildTestSuffix: String,
         buildTestPlatformPlaceholder: String,
         filesToWatch: String?,
-        useSeparateOutputBaseForAquery: Bool = false
+        useSeparateOutputBaseForAquery: Bool = false,
+        topLevelRules: [TopLevelRuleType]? = nil
     ) {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
@@ -49,5 +51,6 @@ package struct BaseServerConfig: Equatable {
         self.buildTestPlatformPlaceholder = buildTestPlatformPlaceholder
         self.filesToWatch = filesToWatch
         self.useSeparateOutputBaseForAquery = useSeparateOutputBaseForAquery
+        self.topLevelRules = topLevelRules
     }
 }

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -32,7 +32,7 @@ package struct BaseServerConfig: Equatable, Sendable {
     let buildTestPlatformPlaceholder: String
     let filesToWatch: String?
     let useSeparateOutputBaseForAquery: Bool
-    let topLevelRules: [TopLevelRuleType]?
+    let topLevelRulesToDiscover: [TopLevelRuleType]?
 
     package init(
         bazelWrapper: String,
@@ -42,7 +42,7 @@ package struct BaseServerConfig: Equatable, Sendable {
         buildTestPlatformPlaceholder: String,
         filesToWatch: String?,
         useSeparateOutputBaseForAquery: Bool = false,
-        topLevelRules: [TopLevelRuleType]? = nil
+        topLevelRulesToDiscover: [TopLevelRuleType]? = nil
     ) {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
@@ -51,6 +51,6 @@ package struct BaseServerConfig: Equatable, Sendable {
         self.buildTestPlatformPlaceholder = buildTestPlatformPlaceholder
         self.filesToWatch = filesToWatch
         self.useSeparateOutputBaseForAquery = useSeparateOutputBaseForAquery
-        self.topLevelRules = topLevelRules
+        self.topLevelRulesToDiscover = topLevelRulesToDiscover
     }
 }

--- a/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
@@ -21,7 +21,7 @@ import Foundation
 
 /// The full configuration of the server, including all information needed to operate the BSP.
 /// Created by the BSP based on the initial `BaseServerConfig`` when the LSP sends us the `initialize` request.
-struct InitializedServerConfig: Equatable {
+struct InitializedServerConfig: Equatable, Sendable {
     let baseConfig: BaseServerConfig
     let rootUri: String
     let outputBase: String

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -66,8 +66,35 @@ struct Serve: ParsableCommand {
     @Option(help: "Comma separated list of file globs to watch for changes.")
     var filesToWatch: String?
 
+    @Option(
+        parsing: .singleValue,
+        help:
+            "A top-level rule type to discover targets for (e.g. 'ios_application', 'ios_unit_test'). Can be specified multiple times. If not specified, all supported top-level rule types will be used for target discovery."
+    )
+    var topLevelRule: [String] = []
+
     func run() throws {
         logger.info("`serve` invoked, initializing BSP server...")
+
+        // Parse top-level rules if specified
+        let parsedTopLevelRules: [TopLevelRuleType]?
+        if !topLevelRule.isEmpty {
+            do {
+                parsedTopLevelRules = try topLevelRule.map { ruleString in
+                    guard let ruleType = TopLevelRuleType(rawValue: ruleString) else {
+                        throw ValidationError(
+                            "Invalid top-level rule type: '\(ruleString)'. Supported types: \(TopLevelRuleType.allCases.map(\.rawValue).joined(separator: ", "))"
+                        )
+                    }
+                    return ruleType
+                }
+            } catch {
+                logger.error("Failed to parse top-level rules: \(error)")
+                throw error
+            }
+        } else {
+            parsedTopLevelRules = nil
+        }
 
         let targets: [String]
         if !target.isEmpty {
@@ -79,7 +106,9 @@ struct Serve: ParsableCommand {
                 "No targets specified (--target)! Will now try to discover them. This can cause the BSP to perform poorly if we find too many targets. Prefer using --target explicitly if possible."
             )
             do {
+                let rulesToUse = parsedTopLevelRules ?? TopLevelRuleType.allCases
                 targets = try BazelTargetDiscoverer.discoverTargets(
+                    for: rulesToUse,
                     bazelWrapper: bazelWrapper
                 )
             } catch {
@@ -97,7 +126,8 @@ struct Serve: ParsableCommand {
             buildTestSuffix: buildTestSuffix,
             buildTestPlatformPlaceholder: buildTestPlatformPlaceholder,
             filesToWatch: filesToWatch,
-            useSeparateOutputBaseForAquery: separateAqueryOutput
+            useSeparateOutputBaseForAquery: separateAqueryOutput,
+            topLevelRules: parsedTopLevelRules
         )
         let server = SourceKitBazelBSPServer(baseConfig: config)
         server.run()

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -69,18 +69,18 @@ struct Serve: ParsableCommand {
     @Option(
         parsing: .singleValue,
         help:
-            "A top-level rule type to discover targets for (e.g. 'ios_application', 'ios_unit_test'). Can be specified multiple times. If not specified, all supported top-level rule types will be used for target discovery."
+            "A top-level rule type to discover targets for (e.g. 'ios_application', 'ios_unit_test'). Can be specified multiple times. Only applicable when not passing --target directly. If not specified, all supported top-level rule types will be used for target discovery."
     )
-    var topLevelRule: [String] = []
+    var topLevelRuleToDiscover: [String] = []
 
     func run() throws {
         logger.info("`serve` invoked, initializing BSP server...")
 
         // Parse top-level rules if specified
         let parsedTopLevelRules: [TopLevelRuleType]?
-        if !topLevelRule.isEmpty {
+        if !topLevelRuleToDiscover.isEmpty {
             do {
-                parsedTopLevelRules = try topLevelRule.map { ruleString in
+                parsedTopLevelRules = try topLevelRuleToDiscover.map { ruleString in
                     guard let ruleType = TopLevelRuleType(rawValue: ruleString) else {
                         throw ValidationError(
                             "Invalid top-level rule type: '\(ruleString)'. Supported types: \(TopLevelRuleType.allCases.map(\.rawValue).joined(separator: ", "))"
@@ -127,7 +127,7 @@ struct Serve: ParsableCommand {
             buildTestPlatformPlaceholder: buildTestPlatformPlaceholder,
             filesToWatch: filesToWatch,
             useSeparateOutputBaseForAquery: separateAqueryOutput,
-            topLevelRules: parsedTopLevelRules
+            topLevelRulesToDiscover: parsedTopLevelRules
         )
         let server = SourceKitBazelBSPServer(baseConfig: config)
         server.run()

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -18,6 +18,9 @@ def _setup_sourcekit_bsp_impl(ctx):
     for index_flag in ctx.attr.index_flags:
         bsp_config_argv.append("--index-flag")
         bsp_config_argv.append(index_flag)
+    for top_level_rule in ctx.attr.top_level_rules:
+        bsp_config_argv.append("--top-level-rule")
+        bsp_config_argv.append(top_level_rule)
     files_to_watch = ",".join(ctx.attr.files_to_watch)
     if files_to_watch:
         bsp_config_argv.append("--files-to-watch")
@@ -86,6 +89,10 @@ setup_sourcekit_bsp = rule(
         ),
         "files_to_watch": attr.string_list(
             doc = "A list of file globs to watch for changes.",
+            default = [],
+        ),
+        "top_level_rules": attr.string_list(
+            doc = "A list of top-level rule types to discover targets for (e.g. 'ios_application', 'ios_unit_test'). If not specified, all supported top-level rule types will be used for target discovery.",
             default = [],
         ),
         "build_test_suffix": attr.string(

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -18,8 +18,8 @@ def _setup_sourcekit_bsp_impl(ctx):
     for index_flag in ctx.attr.index_flags:
         bsp_config_argv.append("--index-flag")
         bsp_config_argv.append(index_flag)
-    for top_level_rule in ctx.attr.top_level_rules:
-        bsp_config_argv.append("--top-level-rule")
+    for top_level_rule in ctx.attr.top_level_rules_to_discover:
+        bsp_config_argv.append("--top-level-rule-to-discover")
         bsp_config_argv.append(top_level_rule)
     files_to_watch = ",".join(ctx.attr.files_to_watch)
     if files_to_watch:
@@ -91,8 +91,8 @@ setup_sourcekit_bsp = rule(
             doc = "A list of file globs to watch for changes.",
             default = [],
         ),
-        "top_level_rules": attr.string_list(
-            doc = "A list of top-level rule types to discover targets for (e.g. 'ios_application', 'ios_unit_test'). If not specified, all supported top-level rule types will be used for target discovery.",
+        "top_level_rules_to_discover": attr.string_list(
+            doc = "A list of top-level rule types to discover targets for (e.g. 'ios_application', 'ios_unit_test'). Only applicable when not specifying targets directly. If not specified, all supported top-level rule types will be used for target discovery.",
             default = [],
         ),
         "build_test_suffix": attr.string(


### PR DESCRIPTION
## What

This PR adds a new `--top-level-rule` command-line flag that allows users to specify which top-level rule types should be used when automatically discovering Bazel targets. This provides more granular control over target discovery, improving performance and allowing users to focus on specific types of targets.

### Usage Examples

```bash
# Discover only iOS applications
sourcekit-bazel-bsp serve --top-level-rule ios_application

# Discover iOS apps and unit tests
sourcekit-bazel-bsp serve --top-level-rule ios_application --top-level-rule ios_unit_test

# In BUILD.bazel
setup_sourcekit_bsp(
    name = "setup_bsp",
    targets = ["//MyApp:MyApp"],
    top_level_rules = ["ios_application", "ios_unit_test"],
)
```
