### PR TITLE
Pre-calculate all sdkRoots

### DIFF
--- a/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
@@ -29,6 +29,7 @@ struct InitializedServerConfig: Equatable {
     let devDir: String
     let devToolchainPath: String
     let executionRoot: String
+    let sdkRootPaths: [String: String]
 
     var indexDatabasePath: String {
         outputPath + "/_global_index_database"

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -35,6 +35,11 @@ struct BazelTargetCompilerArgsExtractorTests {
         let mockExecRoot = "/private/var/tmp/_bazel_user/hash123/execroot/__main__"
         let mockOutputBase = "/private/var/tmp/_bazel_user/hash123"
         let mockDevToolchainPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
+        let iosSimSdk =
+            "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
+        let mockSdkRootPaths = [
+            "iphonesimulator": iosSimSdk
+        ]
         let config = InitializedServerConfig(
             baseConfig: BaseServerConfig(
                 bazelWrapper: "bazel",
@@ -49,7 +54,8 @@ struct BazelTargetCompilerArgsExtractorTests {
             outputPath: mockOutputPath,
             devDir: mockDevDir,
             devToolchainPath: mockDevToolchainPath,
-            executionRoot: mockExecRoot
+            executionRoot: mockExecRoot,
+            sdkRootPaths: mockSdkRootPaths
         )
         let extractor = BazelTargetCompilerArgsExtractor(
             commandRunner: mockRunner,

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -60,6 +60,7 @@ struct InitializeHandlerTests {
         )
         commandRunner.setResponse(for: "xcode-select --print-path", response: devDir)
         commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
+        commandRunner.setResponse(for: "xcrun --sdk iphonesimulator --show-sdk-path", response: "sdkiossim")
 
         let handler = InitializeHandler(baseConfig: baseConfig, commandRunner: commandRunner)
 
@@ -76,7 +77,8 @@ struct InitializeHandlerTests {
                     outputPath: outputPath,
                     devDir: devDir,
                     devToolchainPath: toolchain,
-                    executionRoot: executionRoot
+                    executionRoot: executionRoot,
+                    sdkRootPaths: ["iphonesimulator": "sdkiossim"]
                 )
         )
     }

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -49,7 +49,8 @@ struct PrepareHandlerTests {
             outputPath: "/tmp/output_path",
             devDir: "/Applications/Xcode.app/Contents/Developer",
             devToolchainPath: "/a/b/XcodeDefault.xctoolchain/",
-            executionRoot: "/tmp/output_path/execoot/_main"
+            executionRoot: "/tmp/output_path/execoot/_main",
+            sdkRootPaths: ["iphonesimulator": "bar"]
         )
 
         let expectedCommand = "bazel --output_base=/tmp/output_base build //HelloWorld --config=index"
@@ -96,7 +97,8 @@ struct PrepareHandlerTests {
             outputPath: "/tmp/output_path",
             devDir: "/Applications/Xcode.app/Contents/Developer",
             devToolchainPath: "/a/b/XcodeDefault.xctoolchain/",
-            executionRoot: "/tmp/output_path/execroot/_main"
+            executionRoot: "/tmp/output_path/execroot/_main",
+            sdkRootPaths: ["iphonesimulator": "bar"]
         )
 
         let expectedCommand = "bazel --output_base=/tmp/output_base build //HelloWorld //HelloWorld2 --config=index"


### PR DESCRIPTION
Instead of running a sdkRoot check on every aquery, run it once when launching the tool for every SDK that we support.