### PR TITLE
BazelTargetStore: Store info about which targets match to which plats

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -69,7 +69,7 @@ final class PrepareHandler {
         do {
             let labels = try targetStore.stateLock.withLockUnchecked {
                 return try targetsToBuild.map {
-                    try targetStore.platformBuildLabel(forBSPURI: $0.uri).0
+                    try targetStore.platformBuildLabelInfo(forBSPURI: $0.uri).buildTestLabel
                 }
             }
             nonisolated(unsafe) let reply = reply

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
@@ -67,7 +67,9 @@ final class SKOptionsHandler: InvalidatedTargetObserver {
     func handle(request: TextDocumentSourceKitOptionsRequest) throws -> TextDocumentSourceKitOptionsResponse? {
         let (targetUri, bazelTarget, platform, underlyingLibrary) = try targetStore.stateLock.withLockUnchecked {
             let targetUri = request.target.uri
-            let (bazelTarget, platform) = try targetStore.platformBuildLabel(forBSPURI: targetUri)
+            let buildInfo = try targetStore.platformBuildLabelInfo(forBSPURI: targetUri)
+            let bazelTarget = buildInfo.buildTestLabel
+            let platform = buildInfo.parentRuleType
             let underlyingLibrary = try targetStore.bazelTargetLabel(forBSPURI: targetUri)
             return (targetUri, bazelTarget, platform, underlyingLibrary)
         }

--- a/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetStoreFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetStoreFake.swift
@@ -31,6 +31,9 @@ final class BazelTargetStoreFake: BazelTargetStore {
     var fetchTargetsCalled = false
     var fetchTargetsError: Error?
     var mockSrcToBspURIs: [DocumentURI: [DocumentURI]] = [:]
+    var mockPlatformsToTopLevelLabelsMap: [String: [String]] = [:]
+
+    var platformsToTopLevelLabelsMap: [String: [String]] { mockPlatformsToTopLevelLabelsMap }
 
     func fetchTargets() throws -> [BuildTarget] {
         fetchTargetsCalled = true
@@ -55,7 +58,7 @@ final class BazelTargetStoreFake: BazelTargetStore {
         unimplemented()
     }
 
-    func platformBuildLabel(forBSPURI uri: DocumentURI) throws -> (String, TopLevelRuleType) {
+    func platformBuildLabelInfo(forBSPURI uri: URI) throws -> BazelTargetPlatformInfo {
         unimplemented()
     }
 


### PR DESCRIPTION
Simplifies some of the work to unify aqueries. Also makes the output of `platformBuildLabelInfo` slightly better.