### PR TITLE
Pre-aggregate aquery results

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/AqueryResult.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/AqueryResult.swift
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BazelProtobufBindings
+import Foundation
+
+private let logger = makeFileLevelBSPLogger()
+
+enum AqueryResultError: Error, LocalizedError {
+    case duplicateTarget(label: String)
+    case duplicateAction(targetID: UInt32)
+
+    var errorDescription: String? {
+        switch self {
+        case .duplicateTarget(let label):
+            return
+                "Duplicate target found in the aquery! (\(label)) This can happen if a target gets different arguments depending on which top-level target builds it (on the same platform). Currently, the BSP expects the target to be stable in that sense."
+        case .duplicateAction(let targetID):
+            return "Duplicate action ID found in the aquery! (\(targetID)) This is unexpected."
+        }
+    }
+}
+
+/// Small abstraction on top of Analysis_ActionGraphContainer to pre-aggregate the proto results.
+final class AqueryResult {
+    let targets: [String: Analysis_Target]
+    let actions: [UInt32: Analysis_Action]
+
+    init(results: Analysis_ActionGraphContainer) {
+        let targets: [String: Analysis_Target] = results.targets.reduce(into: [:]) { result, target in
+            if result.keys.contains(target.label) {
+                logger.warning(
+                    "Duplicate target found when aquerying (\(target.label))! This can happen if a target gets different arguments depending on which top-level target builds it (on the same platform). Currently, the BSP expects the target to be stable in that sense."
+                )
+            }
+            result[target.label] = target
+        }
+        let actions: [UInt32: Analysis_Action] = results.actions.reduce(into: [:]) { result, action in
+            if result.keys.contains(action.targetID) {
+                logger.warning("Duplicate action ID found when aquerying (\(action.targetID)) ! This is unexpected.")
+            }
+            result[action.targetID] = action
+        }
+        self.targets = targets
+        self.actions = actions
+    }
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetAquerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetAquerier.swift
@@ -37,7 +37,7 @@ enum BazelTargetAquerierError: Error, LocalizedError {
 final class BazelTargetAquerier {
 
     private let commandRunner: CommandRunner
-    private var queryCache = [String: Analysis_ActionGraphContainer]()
+    private var queryCache = [String: AqueryResult]()
 
     init(commandRunner: CommandRunner = ShellCommandRunner()) {
         self.commandRunner = commandRunner
@@ -49,7 +49,7 @@ final class BazelTargetAquerier {
         config: InitializedServerConfig,
         mnemonics: Set<String>,
         additionalFlags: [String]
-    ) throws -> Analysis_ActionGraphContainer {
+    ) throws -> AqueryResult {
         guard !mnemonics.isEmpty else {
             throw BazelTargetAquerierError.noMnemonics
         }
@@ -75,12 +75,13 @@ final class BazelTargetAquerier {
         )
 
         let parsedOutput = try BazelProtobufBindings.parseActionGraph(data: output)
+        let aqueryResult = AqueryResult(results: parsedOutput)
 
         logger.debug("ActionGraphContainer parsed \(parsedOutput.actions.count) actions")
 
-        queryCache[cmd] = parsedOutput
+        queryCache[cmd] = aqueryResult
 
-        return parsedOutput
+        return aqueryResult
     }
 
     func clearCache() {

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/CompilerArgumentsProcessor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/CompilerArgumentsProcessor.swift
@@ -23,22 +23,35 @@ import LanguageServerProtocol
 
 private let logger = makeFileLevelBSPLogger()
 
+enum CompilerArgumentsProcessorError: Error, LocalizedError {
+    case targetNotFound(String)
+    case actionNotFound(String, UInt32)
+
+    var errorDescription: String? {
+        switch self {
+        case .targetNotFound(let target): return "Target \(target) not found in the aquery output."
+        case .actionNotFound(let target, let id):
+            return "Action \(id) for target \(target) not found in the aquery output."
+        }
+    }
+}
+
 enum CompilerArgumentsProcessor {
     // Parses and processes the compilation step for a given target from a larger aquery output.
     static func extractAndProcessCompilerArgs(
-        fromAquery aqueryOutput: Analysis_ActionGraphContainer,
+        fromAquery aqueryOutput: AqueryResult,
         bazelTarget: String,
         contentToQuery: String,
         language: Language,
         sdkRoot: String,
         initializedConfig: InitializedServerConfig
     ) -> [String]? {
-        guard let target = aqueryOutput.targets.first(where: { $0.label == bazelTarget }) else {
-            logger.debug("Target: \(bazelTarget) not found.")
+        guard let target = aqueryOutput.targets[bazelTarget] else {
+            logger.warning("Target \(bazelTarget) not found in the aquery output.")
             return nil
         }
-        guard let action = aqueryOutput.actions.first(where: { $0.targetID == target.id }) else {
-            logger.debug("Action for \(bazelTarget) not found.")
+        guard let action = aqueryOutput.actions[target.id] else {
+            logger.warning("Action \(target.id) for \(bazelTarget) not found in the aquery output.")
             return nil
         }
 


### PR DESCRIPTION
Helper PR for https://github.com/spotify/sourcekit-bazel-bsp/pull/62/files.

This makes so that aqueries pre-calculate everything we will need later on so that we don't need to re-run the data every time.