### PR TITLE
Parse top-level-rule-to-discover with ArgumentParser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,10 @@ let package = Package(
                     name: "LSPBindings",
                     package: "sourcekit-lsp"
                 ),
+                .product(
+                    name: "ArgumentParser",
+                    package: "swift-argument-parser"
+                )
             ],
             exclude: [
                 "BUILD",
@@ -55,7 +59,9 @@ let package = Package(
         ),
         .testTarget(
             name: "SourceKitBazelBSPTests",
-            dependencies: ["SourceKitBazelBSP"],
+            dependencies: [
+                "SourceKitBazelBSP",
+            ],
             resources: [
                 .copy("Resources/aquery.pb"),
                 .copy("Resources/aquery_objc.pb"),

--- a/Sources/SourceKitBazelBSP/BUILD
+++ b/Sources/SourceKitBazelBSP/BUILD
@@ -9,6 +9,7 @@ swift_library(
         "//Sources/BazelProtobufBindings",
         "@swiftpkg_sourcekit_lsp//:BuildServerProtocol",
         "@swiftpkg_sourcekit_lsp//:LSPBindings",
+        "@swiftpkg_swift_argument_parser//:ArgumentParser",
     ],
     package_name = "sourcekit-bazel-bsp",
 )

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
@@ -17,8 +17,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ArgumentParser
+
 // The list of **top-level rules** we know how to process in the BSP.
-public enum TopLevelRuleType: String, CaseIterable, Sendable {
+public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument {
     case iosApplication = "ios_application"
     case iosUnitTest = "ios_unit_test"
     case iosUiTest = "ios_ui_test"

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -24,7 +24,7 @@ import Foundation
 /// Used to bootstrap the connection to sourcekit-lsp, so that later we can create the
 /// more complete `InitializedServerConfig` struct containing all information
 /// needed to operate the server.
-package struct BaseServerConfig: Equatable, Sendable {
+package struct BaseServerConfig: Equatable {
     let bazelWrapper: String
     let targets: [String]
     let indexFlags: [String]
@@ -32,7 +32,6 @@ package struct BaseServerConfig: Equatable, Sendable {
     let buildTestPlatformPlaceholder: String
     let filesToWatch: String?
     let useSeparateOutputBaseForAquery: Bool
-    let topLevelRulesToDiscover: [TopLevelRuleType]?
 
     package init(
         bazelWrapper: String,
@@ -41,8 +40,7 @@ package struct BaseServerConfig: Equatable, Sendable {
         buildTestSuffix: String,
         buildTestPlatformPlaceholder: String,
         filesToWatch: String?,
-        useSeparateOutputBaseForAquery: Bool = false,
-        topLevelRulesToDiscover: [TopLevelRuleType]? = nil
+        useSeparateOutputBaseForAquery: Bool = false
     ) {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
@@ -51,6 +49,5 @@ package struct BaseServerConfig: Equatable, Sendable {
         self.buildTestPlatformPlaceholder = buildTestPlatformPlaceholder
         self.filesToWatch = filesToWatch
         self.useSeparateOutputBaseForAquery = useSeparateOutputBaseForAquery
-        self.topLevelRulesToDiscover = topLevelRulesToDiscover
     }
 }

--- a/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
@@ -21,7 +21,7 @@ import Foundation
 
 /// The full configuration of the server, including all information needed to operate the BSP.
 /// Created by the BSP based on the initial `BaseServerConfig`` when the LSP sends us the `initialize` request.
-struct InitializedServerConfig: Equatable, Sendable {
+struct InitializedServerConfig: Equatable {
     let baseConfig: BaseServerConfig
     let rootUri: String
     let outputBase: String


### PR DESCRIPTION
Turns out we don't need extra logic when using string enums :)