### PR TITLE
Use --preemptible if using only one output base

### DIFF
--- a/Sources/SourceKitBazelBSP/SharedUtils/Shell/CommandRunner.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/Shell/CommandRunner.swift
@@ -64,7 +64,8 @@ extension CommandRunner {
         outputBase: String,
         cmd: String,
         rootUri: String,
-        additionalFlags: [String] = []
+        additionalFlags: [String] = [],
+        additionalStartupFlags: [String] = []
     ) throws -> RunningProcess {
         let indexFlags = baseConfig.indexFlags
         let additionalFlags = additionalFlags.map { " \($0)" }
@@ -74,7 +75,13 @@ extension CommandRunner {
         } else {
             flagsString = (additionalFlags + indexFlags.map { " \($0)" }).joined(separator: "")
         }
-        let cmd = "--output_base=\(outputBase) \(cmd)\(flagsString)"
+        let startupFlagsString: String
+        if additionalStartupFlags.isEmpty {
+            startupFlagsString = ""
+        } else {
+            startupFlagsString = " " + additionalStartupFlags.joined(separator: " ")
+        }
+        let cmd = "--output_base=\(outputBase)\(startupFlagsString) \(cmd)\(flagsString)"
         return try bazel(baseConfig: baseConfig, rootUri: rootUri, cmd: cmd)
     }
 
@@ -84,14 +91,16 @@ extension CommandRunner {
         outputBase: String,
         cmd: String,
         rootUri: String,
-        additionalFlags: [String] = []
+        additionalFlags: [String] = [],
+        additionalStartupFlags: [String] = []
     ) throws -> T {
         let process = try bazelIndexAction(
             baseConfig: baseConfig,
             outputBase: outputBase,
             cmd: cmd,
             rootUri: rootUri,
-            additionalFlags: additionalFlags
+            additionalFlags: additionalFlags,
+            additionalStartupFlags: additionalStartupFlags
         )
         return try process.result()
     }

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -54,7 +54,7 @@ struct PrepareHandlerTests {
         )
 
         let expectedCommand =
-            "bazel --output_base=/tmp/output_base build //HelloWorld:HelloWorld --remote_download_regex=\'.*\\.indexstore/.*|.*\\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$\' --config=index"
+            "bazel --output_base=/tmp/output_base --preemptible build //HelloWorld:HelloWorld --remote_download_regex=\'.*\\.indexstore/.*|.*\\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$\' --config=index"
         commandRunner.setResponse(for: expectedCommand, cwd: rootUri, response: "")
 
         let handler = PrepareHandler(
@@ -103,7 +103,7 @@ struct PrepareHandlerTests {
         )
 
         let expectedCommand =
-            "bazel --output_base=/tmp/output_base build //HelloWorld:HelloWorld //HelloWorld2:HelloWorld2 --remote_download_regex=\'.*\\.indexstore/.*|.*\\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$\' --config=index"
+            "bazel --output_base=/tmp/output_base --preemptible build //HelloWorld:HelloWorld //HelloWorld2:HelloWorld2 --remote_download_regex=\'.*\\.indexstore/.*|.*\\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$\' --config=index"
         commandRunner.setResponse(for: expectedCommand, response: "Build completed")
 
         let handler = PrepareHandler(
@@ -125,5 +125,57 @@ struct PrepareHandlerTests {
         #expect(ranCommands.count == 1)
         #expect(ranCommands[0].command == expectedCommand)
         #expect(ranCommands[0].cwd == "/path/to/project")
+    }
+
+    @Test
+    func skipsPreemptibleFlagIfUsingSeparateOutputBaseForAquery() throws {
+        let commandRunner = CommandRunnerFake()
+        let connection = LSPConnectionFake()
+
+        let rootUri = "/path/to/project"
+        let baseConfig = BaseServerConfig(
+            bazelWrapper: "bazel",
+            targets: ["//HelloWorld"],
+            indexFlags: ["--config=index"],
+            buildTestSuffix: "_(PLAT)_skbsp",
+            buildTestPlatformPlaceholder: "(PLAT)",
+            filesToWatch: nil,
+            useSeparateOutputBaseForAquery: true
+        )
+
+        let initializedConfig = InitializedServerConfig(
+            baseConfig: baseConfig,
+            rootUri: rootUri,
+            outputBase: "/tmp/output_base",
+            outputPath: "/tmp/output_path",
+            devDir: "/Applications/Xcode.app/Contents/Developer",
+            devToolchainPath: "/a/b/XcodeDefault.xctoolchain/",
+            executionRoot: "/tmp/output_path/execoot/_main",
+            sdkRootPaths: ["iphonesimulator": "bar"]
+        )
+
+        let expectedCommand =
+            "bazel --output_base=/tmp/output_base build //HelloWorld:HelloWorld --remote_download_regex=\'.*\\.indexstore/.*|.*\\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$\' --config=index"
+        commandRunner.setResponse(for: expectedCommand, cwd: rootUri, response: "")
+
+        let handler = PrepareHandler(
+            initializedConfig: initializedConfig,
+            targetStore: BazelTargetStoreImpl(initializedConfig: initializedConfig),
+            commandRunner: commandRunner,
+            connection: connection
+        )
+
+        let semaphore = DispatchSemaphore(value: 0)
+        try handler.build(bazelLabels: baseConfig.targets, id: RequestID.number(1)) { error in
+            #expect(error == nil)
+            semaphore.signal()
+        }
+
+        #expect(semaphore.wait(timeout: .now() + 1) == .success)
+
+        let ranCommands = commandRunner.commands
+        #expect(ranCommands.count == 1)
+        #expect(ranCommands[0].command == expectedCommand)
+        #expect(ranCommands[0].cwd == rootUri)
     }
 }


### PR DESCRIPTION
Passing `--preemptible` allows Bazel to automatically cancel existing builds in favor of another one if needed. This is helpful when not using the separate aquery output base because it allows compilation args request to have precedence over index builds.

Sourcekit-lsp is still a bit wonky when requests fail or get cancelled, but you can go back to a working state by adding/removing files so it's not necessarily adding a regression here.