### PR TITLE
Adding support for Objective-C++ compilation

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFiles/WatchedFileChangeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFiles/WatchedFileChangeHandler.swift
@@ -35,6 +35,7 @@ final class WatchedFileChangeHandler {
         "swift",
         "h",
         "m",
+        "mm",
         "c",
         "cpp",
     ]


### PR DESCRIPTION
I am seeing background index file compilation errors against Objective-C++ files because we are attempting to compile Objective-C++ with `clang -x objective-c`

```
[11:27:59 AM] 🟩🟥🟫 [0;1;31merror: [0m[1minvalid argument '-std=c++20' not allowed with 'Objective-C'[0m
```

I also noticed the file watcher isn't picking up Objective-C++ either:
```
Ignoring file change (unsupported extension): file:///<file path>.mm
```

This PR adds in support for watching Objective-C++ files properly setting compiler args for them.

How I tested:
- Added new unit test that validates different files types are watched
- Verified in our codebase that `.mm` files are properly watched and indexed. No more errors as above.