### PR TITLE
Make some logs publicly visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The setup instructions depend on how the IDE integrates with LSPs. You should th
 
 sourcekit-bazel-bsp uses Apple's OSLog infrastructure under the hood. To see the tool's logs, run `log stream --process sourcekit-bazel-bsp --debug` on a terminal session.
 
-By default, most logs will be redacted for privacy reasons, but you may want to see them for debug and development reasons. To enable extended logging and expose those logs, install the configuration profile at [as described here](https://support.apple.com/guide/mac-help/configuration-profiles-standardize-settings-mh35561/mac#mchlp41bd550) You will then able to see the redacted logs.
+Some logs may be redacted. To enable extended logging and expose those logs, install the configuration profile at [as described here](https://support.apple.com/guide/mac-help/configuration-profiles-standardize-settings-mh35561/mac#mchlp41bd550) You will then able to see the redacted logs.
 
 If you wish for the logs to become redacted again, you can remove the configuration profile [as described here.](https://support.apple.com/guide/mac-help/configuration-profiles-standardize-settings-mh35561/mac#mchlpa04df41.)
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelQueryParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelQueryParser.swift
@@ -101,7 +101,9 @@ enum BazelQueryParser {
                         guard let path = srcMap[$0] else {
                             // FIXME: We should somehow find where the file would be generated to
                             // and register it as a proper generated file.
-                            logger.debug("Skipping \($0): Source does not exist, most likely a generated file.")
+                            logger.debug(
+                                "Skipping \($0, privacy: .public): Source does not exist, most likely a generated file."
+                            )
                             return nil
                         }
                         return try URI(string: path)

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -70,7 +70,7 @@ final class BazelTargetQuerier {
     ) throws -> [(String, TopLevelRuleType)] {
         let targetQuery = config.baseConfig.targets.joined(separator: " union ")
 
-        logger.info("Processing top level rules request for \(targetQuery)")
+        logger.info("Processing top level rules request for \(targetQuery, privacy: .public)")
 
         if let cached = topLevelRuleCache[targetQuery] {
             logger.debug("Returning cached results")
@@ -119,7 +119,7 @@ final class BazelTargetQuerier {
         let depsQuery = Self.queryDepsString(forTargets: targets)
         let cacheKey = "\(kindsFilter)+\(depsQuery)"
 
-        logger.info("Processing query request for \(cacheKey)")
+        logger.info("Processing query request for \(cacheKey, privacy: .public)")
 
         if let cached = queryCache[cacheKey] {
             logger.debug("Returning cached results")
@@ -140,7 +140,7 @@ final class BazelTargetQuerier {
             throw BazelTargetQuerierError.invalidQueryOutput
         }
 
-        logger.debug("Parsed \(targets.count) targets")
+        logger.debug("Parsed \(targets.count, privacy: .public) targets")
         queryCache[cacheKey] = targets
 
         return targets
@@ -166,7 +166,7 @@ final class BazelTargetQuerier {
 
         let cacheKey = "\(kindsFilter)+\(depsQuery)"
 
-        logger.info("Processing dependency graph request for \(cacheKey)")
+        logger.info("Processing dependency graph request for \(cacheKey, privacy: .public)")
 
         if let cached = dependencyGraphCache[cacheKey] {
             logger.debug("Returning cached results")

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -194,7 +194,7 @@ final class BazelTargetStoreImpl: BazelTargetStore {
         )
         let topLevelTargets = topLevelTargetData.map { $0.0 }
 
-        logger.debug("Queried top-level target data: \(topLevelTargetData)")
+        logger.debug("Queried top-level target data: \(topLevelTargetData, privacy: .public)")
 
         // Parse the target dependencies for the top-level targets.
         // This doesn't include information about which top-level app a target belongs to,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BuildTargetsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BuildTargetsHandler.swift
@@ -46,7 +46,7 @@ final class BuildTargetsHandler {
             let result = try targetStore.stateLock.withLockUnchecked {
                 return try targetStore.fetchTargets()
             }
-            logger.debug("Found \(result.count) targets")
+            logger.debug("Found \(result.count, privacy: .public) targets")
             logger.logFullObjectInMultipleLogMessages(
                 level: .debug,
                 header: "Target list",

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -78,18 +78,18 @@ final class InitializeHandler {
         baseConfig: BaseServerConfig,
     ) throws -> InitializedServerConfig {
         let rootUri = request.rootUri.arbitrarySchemeURL.path
-        logger.debug("rootUri: \(rootUri)")
+        logger.debug("rootUri: \(rootUri, privacy: .public)")
         let regularOutputBase = URL(
             fileURLWithPath: try commandRunner.bazel(baseConfig: baseConfig, rootUri: rootUri, cmd: "info output_base")
         )
-        logger.debug("regularOutputBase: \(regularOutputBase)")
+        logger.debug("regularOutputBase: \(regularOutputBase, privacy: .public)")
 
         // Setup the special output base path where we will run indexing commands from.
         let regularOutputBaseLastPath = regularOutputBase.lastPathComponent
         let outputBase = regularOutputBase.deletingLastPathComponent().appendingPathComponent(
             "\(regularOutputBaseLastPath)-sourcekit-bazel-bsp"
         ).path
-        logger.debug("outputBase: \(outputBase)")
+        logger.debug("outputBase: \(outputBase, privacy: .public)")
 
         // Now, get the full output path based on the above output base.
         let outputPath: String = try commandRunner.bazelIndexAction(
@@ -98,7 +98,7 @@ final class InitializeHandler {
             cmd: "info output_path",
             rootUri: rootUri
         )
-        logger.debug("outputPath: \(outputPath)")
+        logger.debug("outputPath: \(outputPath, privacy: .public)")
 
         // Get the execution root based on the above output base.
         let executionRoot: String = try commandRunner.bazelIndexAction(
@@ -107,16 +107,16 @@ final class InitializeHandler {
             cmd: "info execution_root",
             rootUri: rootUri
         )
-        logger.debug("executionRoot: \(executionRoot)")
+        logger.debug("executionRoot: \(executionRoot, privacy: .public)")
 
         // Collecting the rest of the env's details
         let devDir: String = try commandRunner.run("xcode-select --print-path")
         let toolchain = try getToolchainPath(with: commandRunner)
         let sdkRootPaths: [String: String] = getSDKRootPaths(with: commandRunner)
 
-        logger.debug("devDir: \(devDir)")
-        logger.debug("toolchain: \(toolchain)")
-        logger.debug("sdkRootPaths: \(sdkRootPaths)")
+        logger.debug("devDir: \(devDir, privacy: .public)")
+        logger.debug("toolchain: \(toolchain, privacy: .public)")
+        logger.debug("sdkRootPaths: \(sdkRootPaths, privacy: .public)")
 
         return InitializedServerConfig(
             baseConfig: baseConfig,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -107,7 +107,7 @@ final class PrepareHandler {
         id: RequestID,
         completion: @escaping ((ResponseError?) -> Void)
     ) throws {
-        logger.info("Will build \(labelsToBuild.joined(separator: ", "))")
+        logger.info("Will build \(labelsToBuild.joined(separator: ", "), privacy: .public)")
 
         nonisolated(unsafe) let completion = completion
         try currentTaskLock.withLock { [commandRunner, initializedConfig] currentTask in
@@ -121,11 +121,11 @@ final class PrepareHandler {
             )
             process.setTerminationHandler { code, stderr in
                 if code == 0 {
-                    logger.info("Finished building! (Request ID: \(id.description))")
+                    logger.info("Finished building! (Request ID: \(id.description), privacy: .public)")
                     completion(nil)
                 } else {
                     if code == 8 {
-                        logger.info("Build (Request ID: \(id.description)) was cancelled.")
+                        logger.info("Build (Request ID: \(id.description), privacy: .public) was cancelled.")
                         completion(ResponseError.cancelled)
                     } else {
                         logger.logFullObjectInMultipleLogMessages(

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetAquerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetAquerier.swift
@@ -57,7 +57,7 @@ final class BazelTargetAquerier {
 
         let otherFlags = additionalFlags.joined(separator: " ") + " --output proto"
         let cmd = "aquery \"mnemonic('\(mnemonicsFilter)', \(depsQuery))\" \(otherFlags)"
-        logger.info("Processing aquery request for \(targets)")
+        logger.info("Processing aquery request for \(targets, privacy: .public)")
 
         if let cached = queryCache[cmd] {
             logger.debug("Returning cached results")

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -147,7 +147,7 @@ final class BazelTargetCompilerArgsExtractor {
             strategy: strategy
         )
 
-        logger.info("Fetching compiler args for \(cacheKey)")
+        logger.info("Fetching compiler args for \(cacheKey, privacy: .public)")
         if let cached = argsCache[cacheKey] {
             logger.debug("Returning cached results")
             return cached
@@ -162,7 +162,7 @@ final class BazelTargetCompilerArgsExtractor {
         // Then, search for the relevant compilation step within the aquery.
         // Start by getting data about this target's top-level parent that we're using as a reference.
         let parentAction = try getParentAction(forTarget: platformInfo, fromAquery: aquery)
-        logger.debug("Parent configuration id: \(parentAction.configurationID)")
+        logger.debug("Parent configuration id: \(parentAction.configurationID, privacy: .public)")
 
         // Then, find the target compilation step that matches the parent data we just extracted.
         let targetAction = try getTargetAction(

--- a/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
@@ -41,7 +41,7 @@ final class TargetSourcesHandler {
         _ id: RequestID
     ) throws -> BuildTargetSourcesResponse {
         let targets = request.targets
-        logger.info("Fetching sources for \(targets.count) targets")
+        logger.info("Fetching sources for \(targets.count, privacy: .public) targets")
 
         let srcs: [SourcesItem] = try targetStore.stateLock.withLockUnchecked {
             var srcs: [SourcesItem] = []
@@ -55,7 +55,9 @@ final class TargetSourcesHandler {
 
         let count = srcs.reduce(0) { $0 + $1.sources.count }
 
-        logger.info("Returning \(srcs.count) source specs (\(count) total source entries)")
+        logger.info(
+            "Returning \(srcs.count, privacy: .public) source specs (\(count, privacy: .public) total source entries"
+        )
 
         return BuildTargetSourcesResponse(items: srcs)
     }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFiles/WatchedFileChangeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFiles/WatchedFileChangeHandler.swift
@@ -56,7 +56,9 @@ final class WatchedFileChangeHandler {
         // See SourceKitLSPServer.didChangeWatchedFiles in sourcekit-lsp for more details.
         let changes = notification.changes.filter { change in
             guard isSupportedFile(uri: change.uri) else {
-                logger.debug("Ignoring file change (unsupported extension): \(change.uri.stringValue)")
+                logger.debug(
+                    "Ignoring file change (unsupported extension): \(change.uri.stringValue, privacy: .public)"
+                )
                 return false
             }
             return true
@@ -68,7 +70,9 @@ final class WatchedFileChangeHandler {
         }
 
         for change in changes {
-            logger.debug("File change: \(change.uri.stringValue) \(change.type.rawValue)")
+            logger.debug(
+                "File change: \(change.uri.stringValue, privacy: .public) \(change.type.rawValue, privacy: .public)"
+            )
         }
 
         // In this case, we keep the lock until the very end of the notification to avoid race conditions
@@ -76,7 +80,7 @@ final class WatchedFileChangeHandler {
         // Also because we need the targetStore at multiple points of this function.
         let invalidatedTargets = targetStore.stateLock.withLockUnchecked {
 
-            logger.info("Received \(changes.count) file changes")
+            logger.info("Received \(changes.count, privacy: .public) file changes")
 
             let deletedFiles = changes.filter { $0.type == .deleted }
             let createdFiles = changes.filter { $0.type == .created }
@@ -90,7 +94,7 @@ final class WatchedFileChangeHandler {
                         }
                     }
                 } catch {
-                    logger.error("Error calculating deleted targets: \(error)")
+                    logger.error("Error calculating deleted targets: \(error, privacy: .public)")
                     return []
                 }
             }()
@@ -130,7 +134,7 @@ final class WatchedFileChangeHandler {
                         }
                     }
                 } catch {
-                    logger.error("Error calculating created targets: \(error)")
+                    logger.error("Error calculating created targets: \(error, privacy: .public)")
                     return []
                 }
             }()

--- a/Sources/SourceKitBazelBSP/Server/MessageHandler/BSPMessageHandler.swift
+++ b/Sources/SourceKitBazelBSP/Server/MessageHandler/BSPMessageHandler.swift
@@ -60,11 +60,13 @@ final class BSPMessageHandler: MessageHandler {
     }
 
     func handle<Notification: NotificationType>(_ notification: Notification) {
-        logger.info("Received notification: \(Notification.method)")
+        logger.info("Received notification: \(Notification.method, privacy: .public)")
         do {
             let handler = try getHandler(for: notification, state: state)
             try handler(notification)
-        } catch { logger.error("Error while handling BSP notification: \(error.localizedDescription)") }
+        } catch {
+            logger.error("Error while handling BSP notification: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     func handle<Request: RequestType>(
@@ -72,21 +74,23 @@ final class BSPMessageHandler: MessageHandler {
         id: RequestID,
         reply: @escaping (LSPResult<Request.Response>) -> Void
     ) {
-        logger.info("Received request: \(Request.method)")
+        logger.info("Received request: \(Request.method, privacy: .public)")
         do {
             let handler = try getHandler(for: request, id, reply, state: state)
             handler(request, id) { [buildLSPError] result in
                 do {
                     let response = try result.get()
-                    logger.info("Replying to \(Request.method)")
+                    logger.info("Replying to \(Request.method, privacy: .public)")
                     reply(.success(response))
                 } catch {
-                    logger.error("Error while replying to \(Request.method): \(error.localizedDescription)")
+                    logger.error(
+                        "Error while replying to \(Request.method, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                    )
                     reply(.failure(buildLSPError(error)))
                 }
             }
         } catch {
-            logger.error("Error while handling BSP request: \(error.localizedDescription)")
+            logger.error("Error while handling BSP request: \(error.localizedDescription, privacy: .public)")
             reply(.failure(buildLSPError(from: error)))
         }
     }

--- a/Sources/SourceKitBazelBSP/SharedUtils/Shell/RunningProcess.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/Shell/RunningProcess.swift
@@ -82,7 +82,7 @@ public final class RunningProcess: Sendable {
         let (stdoutData, stderrString): (T, String) = self.outputs()
 
         guard wrappedProcess.terminationStatus == 0 else {
-            logger.debug("Command failed: \(self.cmd)")
+            logger.debug("Command failed: \(self.cmd, privacy: .public)")
             throw ShellCommandRunnerError.failed(cmd, stderrString)
         }
 

--- a/Sources/SourceKitBazelBSP/SharedUtils/Shell/ShellCommandRunner.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/Shell/ShellCommandRunner.swift
@@ -55,7 +55,7 @@ struct ShellCommandRunner: CommandRunner {
 
         runningProcess.attachPipes()
 
-        logger.info("Running shell: \(cmd)")
+        logger.info("Running shell: \(cmd, privacy: .public)")
         try process.run()
 
         return runningProcess

--- a/Sources/SourceKitBazelBSP/SharedUtils/SplitLogMessage.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/SplitLogMessage.swift
@@ -61,8 +61,8 @@ extension Logger {
             self.log(
                 level: level,
                 """
-                \(header) (\(i + 1)/\(maxChunkCount))
-                \(loggableChunk)
+                \(header, privacy: .public) (\(i + 1, privacy: .public)/\(maxChunkCount, privacy: .public))
+                \(loggableChunk, privacy: .public)
                 """
             )
         }


### PR DESCRIPTION
This allows them to render in Console.app without any workarounds. AFAICT theres nothing sensitive about these logs that would require them to be redacted. This greatly helps debug issues with the BSP, especially in corporate environments where installing a profile for logs is not possible.