### PR TITLE
Add better logging for cli parsing errors

### DIFF
--- a/Sources/sourcekit-bazel-bsp/SourcekitBazelBsp.swift
+++ b/Sources/sourcekit-bazel-bsp/SourcekitBazelBsp.swift
@@ -20,12 +20,36 @@
 import ArgumentParser
 import SourceKitBazelBSP
 
-@main
-struct SourcekitBazelBsp: ParsableCommand {
+private let logger = makeFileLevelBSPLogger()
+
+struct SourcekitBazelBspCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A Build Server Protocol server for Bazel, for usage with SourceKit-LSP.",
         version: sourcekitBazelBSPVersion,
         subcommands: [Serve.self],
         defaultSubcommand: Serve.self
     )
+}
+
+@main
+struct SourcekitBazelBsp {
+    static func main() throws {
+        var command: ParsableCommand
+
+        // Parse the command
+        do {
+            command = try SourcekitBazelBspCommand.parseAsRoot()
+        } catch {
+            logger.fault("Failed to parse arguments for build server: \(error, privacy: .public)")
+            throw ExitCode(1)
+        }
+
+        // Run the command
+        do {
+            try command.run()
+        } catch {
+            logger.fault("Failed to run build server: \(error, privacy: .public)")
+            throw ExitCode(1)
+        }
+    }
 }


### PR DESCRIPTION
If flags are provided incorrectly from `.bsp/skbsp.json` the cli crashes and previously would not display any meaningful message to debug. This updates it to display the parsing issues in the log

<img width="975" height="575" alt="Screenshot 2025-10-22 at 9 33 22 PM" src="https://github.com/user-attachments/assets/cbf1e435-0595-4c4d-a445-a35635390300" />
