### PR TITLE
Add macOS CLI app example

### DIFF
--- a/Example/HelloWorld/BUILD
+++ b/Example/HelloWorld/BUILD
@@ -1,5 +1,5 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test")
-load("@build_bazel_rules_apple//apple:macos.bzl", "macos_application", "macos_unit_test")
+load("@build_bazel_rules_apple//apple:macos.bzl", "macos_application", "macos_command_line_application", "macos_unit_test")
 load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_application", "watchos_extension", "watchos_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_interop_hint")
 load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template_rule")
@@ -136,6 +136,16 @@ hello_swift_library(
     platforms = ["macos"],
 )
 
+## MARK: MacOS CLI targets
+
+hello_swift_library(
+    name = "MacCLIAppLib",
+    module_name = "MacCLIAppLib",
+    srcs = glob(["MacCLIApp/MacCLIAppLib/Sources/*.swift"]),
+    deps = [":TodoModels"],
+    platforms = ["macos"],
+)
+
 ## MARK: Top level targets
 
 ios_unit_test(
@@ -189,6 +199,14 @@ macos_unit_test(
     deps = [":MacAppTestsLib"],
 )
 
+macos_command_line_application(
+    name = "HelloWorldMacCLIApp",
+    bundle_id = "com.example.HelloWorld.MacCLI",
+    infoplists = ["Resources/MacCLIApp-Info.plist"],
+    minimum_os_version = MACOS_MINIMUM_OS_VERSION,
+    deps = [":MacCLIAppLib"],
+)
+
 # Project setup
 
 setup_sourcekit_bsp(
@@ -209,6 +227,7 @@ setup_sourcekit_bsp(
 		"//HelloWorld:HelloWorldWatchTests",
 		"//HelloWorld:HelloWorldMacApp",
 		"//HelloWorld:HelloWorldMacTests",
+		"//HelloWorld:HelloWorldMacCLIApp",
     ],
     build_test_suffix = "_(PLAT)_skbsp",
 	build_test_platform_placeholder = "(PLAT)",

--- a/Example/HelloWorld/MacCLIApp/MacCLIAppLib/Sources/main.swift
+++ b/Example/HelloWorld/MacCLIApp/MacCLIAppLib/Sources/main.swift
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import TodoModels
+
+let args = CommandLine.arguments
+print(args)
+print(TodoItem.self)

--- a/Example/HelloWorld/Resources/MacCLIApp-Info.plist
+++ b/Example/HelloWorld/Resources/MacCLIApp-Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>24G84</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>MacApp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.example.HelloWorld.MacCLI</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>MacApp</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>24A336</string>
+	<key>DTPlatformName</key>
+	<string>macosx</string>
+	<key>DTPlatformVersion</key>
+	<string>15.0</string>
+	<key>DTSDKBuild</key>
+	<string>24A336</string>
+	<key>DTSDKName</key>
+	<string>macosx15.0</string>
+	<key>DTXcode</key>
+	<string>1600</string>
+	<key>DTXcodeBuild</key>
+	<string>16A242d</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>15.0</string>
+</dict>
+</plist>

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -232,12 +232,13 @@ final class BazelTargetStoreImpl: BazelTargetStore {
 
         // Now, run a broad aquery against all top-level targets
         // to get the compiler arguments for all targets we're interested in.
-        // We pass BundleTreeApp as a trick to gain access to the parent's configuration id.
+        // We pass BundleTreeApp and SignBinary as a trick to gain access to the parent's configuration id.
         // We can then use this to locate the exact variant of the target we are looking for.
+        // BundleTreeApp is used by most rule types, while SignBinary is for macOS CLI apps specifically.
         targetsAqueryResult = try bazelTargetAquerier.aquery(
             targets: topLevelLabelToRuleMap.keys.map { $0 },
             config: initializedConfig,
-            mnemonics: ["SwiftCompile", "ObjcCompile", "CppCompile", "BundleTreeApp"],
+            mnemonics: ["SwiftCompile", "ObjcCompile", "CppCompile", "BundleTreeApp", "SignBinary"],
             additionalFlags: [
                 "--noinclude_artifacts",
                 "--noinclude_aspects",


### PR DESCRIPTION
- Fixes the BSP not working for macOS CLI targets as they don't have the BundleTreeApp mnemonic. We can instead pass SignBinary to fetch this info.
- Added a macOS CLI example to our example project.