### PR TITLE
Handle more edge cases when parsing targets

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -62,10 +62,9 @@ final class BazelTargetQuerier {
 
     func queryTargets(
         config: InitializedServerConfig,
-        topLevelRuleKinds: Set<String>,
         dependencyKinds: Set<String>,
     ) throws -> [BlazeQuery_Target] {
-        if topLevelRuleKinds.isEmpty || dependencyKinds.isEmpty {
+        if dependencyKinds.isEmpty {
             throw BazelTargetQuerierError.noKinds
         }
 
@@ -77,12 +76,11 @@ final class BazelTargetQuerier {
         let providedTargetsQuerySet = "set(\(providedTargets.joined(separator: " ")))"
 
         // NOTE: important to sort for determinism
-        let topLevelKindsFilter = topLevelRuleKinds.sorted().joined(separator: "|")
         let dependencyKindsFilter = dependencyKinds.sorted().joined(separator: "|")
 
         // Collect the top-level targets -> collect these targets' dependencies
         let topLevelTargetsQuery = """
-            let topLevelTargets = kind("\(topLevelKindsFilter)", \(providedTargetsQuerySet)) in \
+            let topLevelTargets = kind("rule", \(providedTargetsQuerySet)) in \
               $topLevelTargets \
               union \
               kind("\(dependencyKindsFilter)", deps($topLevelTargets))

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
@@ -20,7 +20,7 @@
 import ArgumentParser
 
 // The list of **top-level rules** we know how to process in the BSP.
-public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument {
+public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument, Sendable {
     case iosApplication = "ios_application"
     case iosUnitTest = "ios_unit_test"
     case iosUiTest = "ios_ui_test"

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -45,12 +45,30 @@ package struct BaseServerConfig: Equatable {
         indexBuildBatchSize: Int? = nil
     ) {
         self.bazelWrapper = bazelWrapper
-        self.targets = targets
         self.indexFlags = indexFlags
         self.buildTestSuffix = buildTestSuffix
         self.buildTestPlatformPlaceholder = buildTestPlatformPlaceholder
         self.filesToWatch = filesToWatch
         self.useSeparateOutputBaseForAquery = useSeparateOutputBaseForAquery
         self.indexBuildBatchSize = indexBuildBatchSize
+
+        // We need to post-process the target list provided by the user
+        // because the queries will always return the "full" label.
+        // e.g: "//foo/bar" -> "//foo/bar:bar"
+        self.targets = targets.map { $0.toFullLabel() }
+    }
+}
+
+extension String {
+    func toFullLabel() -> String {
+        let paths = components(separatedBy: "/")
+        let lastComponent = paths.last
+        if lastComponent?.contains(":") == true {
+            return self
+        } else if let lastComponent = lastComponent {
+            return "\(self):\(lastComponent)"
+        } else {
+            return self
+        }
     }
 }

--- a/Tests/SourceKitBazelBSPTests/BazelTargetParserTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetParserTests.swift
@@ -54,16 +54,14 @@ struct BazelTargetParserTests {
         let querier = BazelTargetQuerier(commandRunner: runner)
         let toolchainPath = "/path/to/toolchain"
         let command =
-            "bazel --output_base=/path/to/output/base query \'let topLevelTargets = kind(\"ios_application|ios_unit_test\", set(//HelloWorld:HelloWorld)) in   $topLevelTargets   union   kind(\"objc_library|source file|swift_library\", deps($topLevelTargets))\' --notool_deps --noimplicit_deps --output streamed_proto"
+            "bazel --output_base=/path/to/output/base query \'let topLevelTargets = kind(\"rule\", set(//HelloWorld:HelloWorld)) in   $topLevelTargets   union   kind(\"objc_library|source file|swift_library\", deps($topLevelTargets))\' --notool_deps --noimplicit_deps --output streamed_proto"
 
-        let topLevelRuleKinds: Set<String> = ["ios_application", "ios_unit_test"]
         let dependencyKinds: Set<String> = ["objc_library", "source file", "swift_library"]
 
         runner.setResponse(for: command, cwd: rootUri, response: mockProtobuf)
 
         let targets = try querier.queryTargets(
             config: initializedConfig,
-            topLevelRuleKinds: topLevelRuleKinds,
             dependencyKinds: dependencyKinds
         )
 

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -54,7 +54,7 @@ struct PrepareHandlerTests {
         )
 
         let expectedCommand =
-            "bazel --output_base=/tmp/output_base build //HelloWorld --remote_download_regex=\'.*\\.indexstore/.*|.*\\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$\' --config=index"
+            "bazel --output_base=/tmp/output_base build //HelloWorld:HelloWorld --remote_download_regex=\'.*\\.indexstore/.*|.*\\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$\' --config=index"
         commandRunner.setResponse(for: expectedCommand, cwd: rootUri, response: "")
 
         let handler = PrepareHandler(
@@ -103,7 +103,7 @@ struct PrepareHandlerTests {
         )
 
         let expectedCommand =
-            "bazel --output_base=/tmp/output_base build //HelloWorld //HelloWorld2 --remote_download_regex=\'.*\\.indexstore/.*|.*\\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$\' --config=index"
+            "bazel --output_base=/tmp/output_base build //HelloWorld:HelloWorld //HelloWorld2:HelloWorld2 --remote_download_regex=\'.*\\.indexstore/.*|.*\\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$\' --config=index"
         commandRunner.setResponse(for: expectedCommand, response: "Build completed")
 
         let handler = PrepareHandler(


### PR DESCRIPTION
One side-effect of https://github.com/spotify/sourcekit-bazel-bsp/pull/82 is that the BSP lost the ability to automatically translate short-form labels like `//HelloWorld` to the full `//HelloWorld:HelloWorld` label that the queries will return, but we can deal with this by making this conversion on our end.

Also slightly changes how we execute the query to make it easier/faster to detect the case where the user passes an unsupported rule as a top-level target. The previous logic worked, but it required more logic to detect this case efficiently since we needed to check if something was missing from the output rather than if it had the wrong type.