### PR TITLE
Delete existing binary before replacing

### DIFF
--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -13,6 +13,9 @@ target_bsp_config_path="$bsp_folder_path/skbsp.json"
 target_sourcekit_bazel_bsp_path="$bsp_folder_path/sourcekit-bazel-bsp"
 
 cp "$bsp_config_path" "$target_bsp_config_path"
+
+# Delete the existing binary first to avoid issues when running this while a server is running.
+rm -f "$target_sourcekit_bazel_bsp_path" || true
 cp "$sourcekit_bazel_bsp_path" "$target_sourcekit_bazel_bsp_path"
 
 chmod +w "$target_bsp_config_path"


### PR DESCRIPTION
Ran into a weird issue where running `bazelisk run` while the IDE was opened caused some weird binary corruption issue.