### PR TITLE
Add support for jump to definition 

### DIFF
--- a/Example/.vscode/settings.json
+++ b/Example/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "swift.sourcekit-lsp.backgroundIndexing": "on",
     "swift.sourcekit-lsp.trace.server": "messages",
+    "swift.sourcekit-lsp.serverPath":  "/Users/mostafa.essam/Library/Developer/Xcode/DerivedData/sourcekit-lsp-hjlrhelrwpehrpezdvulxehkrvsc/Build/Products/Debug/sourcekit-lsp",
     "terminal.integrated.profiles.osx": {
         "zsh": {
             "path": "/bin/zsh",

--- a/Example/.vscode/settings.json
+++ b/Example/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
     "swift.sourcekit-lsp.backgroundIndexing": "on",
     "swift.sourcekit-lsp.trace.server": "messages",
-    "swift.sourcekit-lsp.serverPath":  "/Users/mostafa.essam/Library/Developer/Xcode/DerivedData/sourcekit-lsp-hjlrhelrwpehrpezdvulxehkrvsc/Build/Products/Debug/sourcekit-lsp",
     "terminal.integrated.profiles.osx": {
         "zsh": {
             "path": "/bin/zsh",

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,11 @@ let package = Package(
             revision: "1.5.0"
         ),
         .package(
-            url: "https://github.com/rockbruno/sourcekit-lsp",
-            revision: "c052baae81ec6532bb2f939a21acc4650fb1dc86"
+            url: "https://github.com/swiftlang/sourcekit-lsp",
+            revision: "0e061c5c1075152bc2e6187679a11b81d0c3e326" // latest main commit November 29, 2025
+            // TODO: Ideally it would be better to upstream these changes to sourceKit-lsp
+            // url: "https://github.com/rockbruno/sourcekit-lsp",
+            // revision: "c052baae81ec6532bb2f939a21acc4650fb1dc86"
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",
@@ -55,7 +58,7 @@ let package = Package(
                 .product(
                     name: "ArgumentParser",
                     package: "swift-argument-parser"
-                )
+                ),
             ],
         ),
         .testTarget(
@@ -71,7 +74,7 @@ let package = Package(
         .target(
             name: "BazelProtobufBindings",
             dependencies: [
-                .product(name: "SwiftProtobuf", package: "swift-protobuf")
+                .product(name: "SwiftProtobuf", package: "swift-protobuf"),
             ],
             exclude: [
                 "README.md",
@@ -87,6 +90,6 @@ let package = Package(
                 .copy("Resources/actions.pb"),
                 .copy("Resources/streamdeps.pb"),
             ],
-        )
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,12 @@ let package = Package(
     ],
     dependencies: [
         .package(
+            url:
+            "https://github.com/swiftlang/swift-tools-protocols",
+            revision: "f86b413a803761408e5e718912c46d75a340801b"
+        ),
+
+        .package(
             url: "https://github.com/apple/swift-argument-parser",
             revision: "1.5.0"
         ),
@@ -48,12 +54,16 @@ let package = Package(
             dependencies: [
                 "BazelProtobufBindings",
                 .product(
-                    name: "BuildServerProtocol",
-                    package: "sourcekit-lsp"
+                    name: "LanguageServerProtocolTransport",
+                    package: "swift-tools-protocols"
                 ),
                 .product(
-                    name: "LSPBindings",
-                    package: "sourcekit-lsp"
+                    name: "BuildServerProtocol",
+                    package: "swift-tools-protocols"
+                ),
+                .product(
+                    name: "ToolsProtocolsSwiftExtensions",
+                    package: "swift-tools-protocols"
                 ),
                 .product(
                     name: "ArgumentParser",

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -204,10 +204,10 @@ final class InitializeHandler {
             data: SourceKitInitializeBuildResponseData(
                 indexDatabasePath: initializedConfig.indexDatabasePath,
                 indexStorePath: initializedConfig.indexStorePath,
-                multiTargetPreparation: MultiTargetPreparationSupport(
-                    supported: true,
-                    batchSize: batchSize
-                ),
+//                multiTargetPreparation: MultiTargetPreparationSupport(
+//                    supported: true,
+//                    batchSize: batchSize
+//                ),
                 outputPathsProvider: nil,
                 prepareProvider: true,
                 sourceKitOptionsProvider: true,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -123,16 +123,12 @@ final class PrepareHandler {
                 bazelLabels: labelsToBuild,
                 extraArgs: extraArgs,
                 id: id
-            ) { [weak self, connection] error in
+            ) { [connection] error in
                 if let error = error {
                     connection?.finishTask(id: taskId, status: .error)
                     reply(.failure(error))
                 }
                 connection?.finishTask(id: taskId, status: .ok)
-
-                // Notify sourcekit-lsp that the targets have changed after successful preparation
-                self?.notifyTargetsDidChange(targetsToBuild, connection: connection)
-
                 reply(.success(VoidResponse()))
             }
         } catch {
@@ -238,22 +234,6 @@ final class PrepareHandler {
         let targetLabels = Set(platformInfo.map { $0.topLevelParentLabel }).sorted()
         let targetNames = targetLabels.joined(separator: ", ")
         return "sourcekit-bazel-bsp: Building \(targetLabels.count) target(s): \(targetNames)"
-    }
-
-    private func notifyTargetsDidChange(
-        _ targets: [BuildTargetIdentifier],
-        connection: LSPConnection?
-    ) {
-        connection?.send(OnBuildTargetDidChangeNotification(
-            changes: targets.map { target in
-                BuildTargetEvent(
-                    target: target,
-                    kind: .changed,
-                    dataKind: nil,
-                    data: nil
-                )
-            }
-        ))
     }
 }
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
@@ -81,9 +81,10 @@ final class TargetSourcesHandler {
 
         if srcPath.hasPrefix(workspaceRoot) {
             // Workspace file -> single execroot location Bazel copies to.
-            // We need to tell the lsp about the path of this file in execution root to later it maps it again to original Workspace path.
+            // We need to tell the LSP about the path of each file in execution root to later help it mapping it again to original Workspace path.
             let relativePath = trimmedRelativePath(fullPath: srcPath, base: workspaceRoot)
-            destinations.append(DocumentURI(filePath: execRoot + "/" + relativePath, isDirectory: true))
+            let destination = DocumentURI(filePath: execRoot + "/" + relativePath, isDirectory: true)
+            destinations.append(destination)
         }
 
         return destinations.isEmpty ? nil : destinations

--- a/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
@@ -37,7 +37,7 @@ final class TargetSourcesHandler {
 
     func buildTargetSources(
         _ request: BuildTargetSourcesRequest,
-        _ id: RequestID
+        _: RequestID
     ) throws -> BuildTargetSourcesResponse {
         let targets = request.targets
         logger.info("Fetching sources for \(targets.count, privacy: .public) targets")

--- a/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
@@ -83,7 +83,7 @@ final class TargetSourcesHandler {
             // Workspace file -> single execroot location Bazel copies to.
             // We need to tell the LSP about the path of each file in execution root to later help it mapping it again to original Workspace path.
             let relativePath = trimmedRelativePath(fullPath: srcPath, base: workspaceRoot)
-            let destination = DocumentURI(filePath: execRoot + "/" + relativePath, isDirectory: true)
+            let destination = DocumentURI(filePath: execRoot + "/" + relativePath, isDirectory: false)
             destinations.append(destination)
         }
 

--- a/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
+++ b/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
@@ -20,7 +20,7 @@
 import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
-import LanguageServerProtocolJSONRPC
+import LanguageServerProtocolTransport
 
 private let logger = makeFileLevelBSPLogger()
 
@@ -130,7 +130,7 @@ package final class SourceKitBazelBSPServer {
     package func run(parkThread: Bool = true) {
         logger.info("Connecting to sourcekit-lsp...")
 
-        connection.start(
+        connection.startJSONRPC(
             receiveHandler: handler,
             closeHandler: {
                 logger.info("Connection closed, exiting.")

--- a/Tests/SourceKitBazelBSPTests/BSPMessageHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BSPMessageHandlerTests.swift
@@ -20,7 +20,7 @@
 import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
-import LanguageServerProtocolJSONRPC
+import LanguageServerProtocolTransport
 import Testing
 
 @testable import SourceKitBazelBSP

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -20,7 +20,7 @@
 import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
-import LanguageServerProtocolJSONRPC
+import LanguageServerProtocolTransport
 import Testing
 
 @testable import SourceKitBazelBSP

--- a/Tests/SourceKitBazelBSPTests/Fakes/LSPConnectionFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/LSPConnectionFake.swift
@@ -19,17 +19,16 @@
 
 import BuildServerProtocol
 import LanguageServerProtocol
-import LanguageServerProtocolJSONRPC
+import LanguageServerProtocolTransport
 
 @testable import SourceKitBazelBSP
 
 final class LSPConnectionFake: LSPConnection {
-
     nonisolated(unsafe) private(set) var startCalled = false
     nonisolated(unsafe) private(set) var startReceivedHandler: MessageHandler?
     nonisolated(unsafe) private(set) var sentNotifications: [any NotificationType] = []
 
-    func start(receiveHandler: MessageHandler, closeHandler: @escaping @Sendable () async -> Void) {
+    func startJSONRPC(receiveHandler: MessageHandler, closeHandler: @escaping @Sendable () async -> Void) {
         startCalled = true
         startReceivedHandler = receiveHandler
     }

--- a/Tests/SourceKitBazelBSPTests/SourceKitBazelBSPServerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/SourceKitBazelBSPServerTests.swift
@@ -19,7 +19,7 @@
 
 import BuildServerProtocol
 import LanguageServerProtocol
-import LanguageServerProtocolJSONRPC
+import LanguageServerProtocolTransport
 import Testing
 
 @testable import SourceKitBazelBSP


### PR DESCRIPTION
<img width="1573" height="352" alt="Screenshot 2025-11-24 at 12 48 15 AM" src="https://github.com/user-attachments/assets/e5376b51-384f-43d7-a880-06ed95273d6b" />

## Support for jump to definition

By using `copyDestinations` for `textDocument/definition`, we let  it know about the execution root as a copy destination relative to the original file in workspace, so later when `sourcekitd` returns the execution root, `BuildServerManager` will try to map it to the mapped workspace path. 

Internal structures inside SourceKit won't calculate the mapped paths until we do one of two things: 
1. send `workspace/synchronize`  : but it appears to be an [experimental](https://github.com/swiftlang/swift-tools-protocols/tree/main/Sources/LanguageServerProtocol/Requests/SynchronizeRequest.swift#L41-L45) feature for [testing purposes 
](https://github.com/ahoppen/sourcekit-lsp/blob/882c990caea25b0e17f2e447e4027c7cc659e086/Sources/SKOptions/ExperimentalFeatures.swift#L51)

2. send `buildTarget/didChange` which will trigger the calculations of copy destinations. which what i did in the PR.


## How to test
1. Compile the branch, make sure that `.bsp/sourcekit-bazel-bsp` in `Example` folder is updated to latest version
```bash
 bazel run //HelloWorld:setup_sourcekit_bsp_example_project_build_tests
```
2. Clone SourceKit, build it, then modify VSCode's Settings to point to compiled one.
```diff
{
    "swift.sourcekit-lsp.backgroundIndexing": "on",
    "swift.sourcekit-lsp.trace.server": "messages",
+   "swift.sourcekit-lsp.serverPath":  "/Users/mostafa.essam/Library/Developer/Xcode/DerivedData/sourcekit-lsp-hjlrhelrwpehrpezdvulxehkrvsc/Build/Products/Debug/sourcekit-lsp",
    "terminal.integrated.profiles.osx": {
        "zsh": {
            "path": "/bin/zsh",
            "args": [
                "-l",
                "-i"
            ]
        }
    }
}
```
3. Have fun !


We need to decide how we can handle the need of latest main branch from `Sourcekit`
i'm not sure if we can override this setting from the config file of the project itself, in case it's possible, we can compile latest upstream and instruct VSCode to use it (?)
