### PR TITLE
PrepareHandler: Dedupe top-level labels

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -102,7 +102,9 @@ final class PrepareHandler {
             let labelsToBuild: [String]
             let extraArgs: [String]
             if initializedConfig.baseConfig.compileTopLevel {
-                labelsToBuild = platformInfo.map { $0.topLevelParentLabel }
+                // We might get repeat labels in this case, so we need to dedupe them.
+                let topLevelLabelsToBuild = Set(platformInfo.map { $0.topLevelParentLabel })
+                labelsToBuild = topLevelLabelsToBuild.sorted()
                 extraArgs = []  // Not applicable in this case
             } else {
                 guard platformInfo.count == 1 else {


### PR DESCRIPTION
When using compile-top-level with batching, you might be requested to build the same parent multiple times. Ideally we would have some caching but I'm not sure yet how to make it thread-safe, so for now I'm deduping them.