### PR TITLE
Add support for passing wildcards to --targets

### DIFF
--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -49,7 +49,8 @@ package struct BaseServerConfig: Equatable {
         // We need to post-process the target list provided by the user
         // because the queries will always return the "full" label.
         // e.g: "//foo/bar" -> "//foo/bar:bar"
-        self.targets = targets.map { $0.toFullLabel() }
+        // We need to also de-dupe them if the user passed wildcards in Serve.swift.
+        self.targets = Set(targets.map { $0.toFullLabel() }).sorted()
     }
 }
 

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -77,7 +77,7 @@ setup_sourcekit_bsp = rule(
         ),
         # We avoid using label_list here to not trigger unnecessary bazel dependency graph checks.
         "targets": attr.string_list(
-            doc = "The *top level* Bazel applications or test targets that this should serve a BSP for. It's best to keep this list small if possible for performance reasons. If not specified, the server will try to discover top-level targets automatically",
+            doc = "The *top level* Bazel applications or test targets that this should serve a BSP for. Wildcards are supported (e.g. //foo/...). It's best to keep this list small if possible for performance reasons. If not specified, the server will try to discover top-level targets automatically",
             mandatory = True,
         ),
         "bazel_wrapper": attr.string(


### PR DESCRIPTION
This adds support for passing wildcard labels directly to targets, so that devs don't have to query targets on their own when trying to implement the BSP at their companies.

Also changes how we discover targets to do something slightly more optimal.