### PR TITLE
Let sourcekit-lsp handle index store paths

### DIFF
--- a/Example/.bazelrc
+++ b/Example/.bazelrc
@@ -13,8 +13,6 @@ common --features=apple.swizzle_absolute_xcttestsourcelocation
 common --features=oso_prefix_is_pwd
 common --features=relative_ast_path
 common --features=swift.cacheable_swiftmodules
-common --features=swift.index_while_building
-common --features=swift.use_global_index_store
 common --features=swift.use_global_module_cache
 common --features=swift.emit_swiftsourceinfo
 common --nolegacy_important_outputs

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -381,26 +381,12 @@ extension BazelTargetCompilerArgsExtractor {
         // Handle remaining necessary adjustments for indexing.
         switch strategy {
         case .objcImpl, .cImpl:
-            compilerArguments.append("-index-store-path")
-            compilerArguments.append(config.indexStorePath)
             compilerArguments.append("-working-directory")
             compilerArguments.append(config.rootUri)
-        case .swiftModule:
-            // For Swift, swap the index store arg with the global cache.
-            // Bazel handles this a bit differently internally, which is why
-            // we need to do this.
-            _editArg("-index-store-path", config.indexStorePath, &compilerArguments)
-        case .cHeader:
+        case .swiftModule, .cHeader:
             break
         }
 
         return compilerArguments
-    }
-
-    private func _editArg(_ arg: String, _ new: String, _ lines: inout [String]) {
-        guard let idx = lines.firstIndex(of: arg) else {
-            return
-        }
-        lines[idx + 1] = new
     }
 }

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -288,7 +288,7 @@ let expectedSwiftResult: [String] = [
     "-file-prefix-map",
     "/Applications/Xcode.app/Contents/Developer=DEVELOPER_DIR",
     "-index-store-path",
-    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/_global_index_store",
+    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0/bin/HelloWorld/HelloWorldLib.indexstore",
     "-index-ignore-system-modules",
     "-enable-bare-slash-regex",
     "-Xfrontend",
@@ -367,8 +367,6 @@ let expectedObjCResult: [String] = [
     "HelloWorld/TodoObjCSupport/Sources/SKDateDistanceCalculator.m",
     "-o",
     "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0/bin/HelloWorld/_objs/TodoObjCSupport/arc/SKDateDistanceCalculator.o",
-    "-index-store-path",
-    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/_global_index_store",
     "-working-directory",
     "/Users/user/Documents/demo-ios-project",
 ]


### PR DESCRIPTION
SourceKit-LSP automatically manages the `-index-store-path` and similar flags. This means there is no need for us to manage this on our end, which also drops the requirement to use `use_global_index_store` (although the path is still kept the same for now to prevent double indexing)