### PR TITLE
Make jump to definition work as early as possible

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
@@ -65,6 +65,8 @@ final class TargetSourcesHandler {
     /// but Bazel works by copying them over to the execroot.
     /// This method calculates this fake path so that sourcekit-lsp can
     /// map the file back to the original workspace path for features like jump to definition.
+    /// FIXME: SourceKit-LSP has a config for defining this statically, but I couldn't figure out
+    /// how to make it work. If we do, we can drop this logic and the FIXME at BuildTargetsHandler.swift.
     func computeCopyDestinations(for src: URI) -> [DocumentURI]? {
         guard let srcPath = src.fileURL?.path else {
             return nil

--- a/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
+++ b/Sources/SourceKitBazelBSP/Server/SourceKitBazelBSPServer.swift
@@ -56,7 +56,7 @@ package final class SourceKitBazelBSPServer {
         // workspace/buildTargets
         let targetStore = BazelTargetStoreImpl(initializedConfig: initializedConfig)
         let buildTargetsHandler = BuildTargetsHandler(targetStore: targetStore, connection: connection)
-        registry.register(syncRequestHandler: buildTargetsHandler.workspaceBuildTargets)
+        registry.register(requestHandler: buildTargetsHandler.workspaceBuildTargets)
 
         // workspace/waitForBuildSystemUpdates
         let waitUpdatesHandler = WaitUpdatesHandler(targetStore: targetStore, connection: connection)


### PR DESCRIPTION
The file mappings only kick in after sending a OnBuildTargetDidChangeNotification notification, so this updates the buildTargets request to do that if this is the first time this is being triggered.