### PR TITLE
Improve argument parsing for the BSP

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
 
         .package(
             url: "https://github.com/apple/swift-argument-parser",
-            revision: "1.5.0"
+            revision: "1.6.2"
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",

--- a/Sources/sourcekit-bazel-bsp/SourcekitBazelBsp.swift
+++ b/Sources/sourcekit-bazel-bsp/SourcekitBazelBsp.swift
@@ -22,6 +22,7 @@ import SourceKitBazelBSP
 
 private let logger = makeFileLevelBSPLogger()
 
+@main
 struct SourcekitBazelBspCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A Build Server Protocol server for Bazel, for usage with SourceKit-LSP.",
@@ -31,25 +32,20 @@ struct SourcekitBazelBspCommand: ParsableCommand {
     )
 }
 
-@main
-struct SourcekitBazelBsp {
+extension SourcekitBazelBspCommand {
     static func main() throws {
         var command: ParsableCommand
-
-        // Parse the command
         do {
-            command = try SourcekitBazelBspCommand.parseAsRoot()
+            command = try parseAsRoot()
         } catch {
-            logger.fault("Failed to parse arguments for build server: \(error, privacy: .public)")
-            throw ExitCode(1)
+            logger.fault("Failed to parse arguments for the BSP: \(error, privacy: .public)")
+            exit(withError: error)
         }
-
-        // Run the command
         do {
             try command.run()
         } catch {
-            logger.fault("Failed to run build server: \(error, privacy: .public)")
-            throw ExitCode(1)
+            logger.fault("Failed to initialize the BSP: \(error, privacy: .public)")
+            exit(withError: error)
         }
     }
 }


### PR DESCRIPTION
The way we were catching errors was causing things like `--help` to not work as expected.