### PR TITLE
fix: merge existing sourcekit-lsp config if it exists

### DIFF
--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -17,7 +17,14 @@ target_sourcekit_bazel_bsp_path="$bsp_folder_path/sourcekit-bazel-bsp"
 target_lsp_config_path="$lsp_folder_path/config.json"
 
 cp "$bsp_config_path" "$target_bsp_config_path"
-cp "$lsp_config_path" "$target_lsp_config_path"
+
+# Merge LSP config if jq is available and existing config exists
+if [ -f "$target_lsp_config_path" ] && command -v jq &> /dev/null; then
+    jq -S -s '.[0] * .[1]' "$target_lsp_config_path" "$lsp_config_path" > "$target_lsp_config_path.tmp"
+    mv "$target_lsp_config_path.tmp" "$target_lsp_config_path"
+else
+    cp "$lsp_config_path" "$target_lsp_config_path"
+fi
 
 # Delete the existing binary first to avoid issues when running this while a server is running.
 rm -f "$target_sourcekit_bazel_bsp_path" || true


### PR DESCRIPTION
Previously we'd overwrite the entire lsp config file. It seems reasonable that users would have potentially other settings configured here. This does a quick and dirty merge of the config.json file using `jq` (if its on the host machine, which should be the case for newer macOS versions)