### PR TITLE
Fix top-level-rule-to-discover not propagating downstream

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetDiscoverer.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetDiscoverer.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+private let logger = makeFileLevelBSPLogger()
+
 public enum BazelTargetDiscovererError: LocalizedError, Equatable {
     case noRulesProvided
     case noTargetsDiscovered
@@ -30,6 +32,7 @@ public enum BazelTargetDiscoverer {
         bazelWrapper: String = "bazel",
         locations: [String] = [],
         additionalFlags: [String] = [],
+        processInfoPath: String?,
         commandRunner: CommandRunner? = nil
     ) throws -> [String] {
         guard !rules.isEmpty else {
@@ -45,6 +48,20 @@ public enum BazelTargetDiscoverer {
         // FIXME: This has a lot of overlap with the Bazel utilities in CommandRunner, but we cannot
         // use them because this logic runs before the actual initialize code that builds all necessary info.
         // So we're duplicating a bunch of this logic here as a result.
+        let cwd: String? = {
+            if let processInfoPath, processInfoPath.hasSuffix("/.bsp/sourcekit-bazel-bsp") {
+                // Remove the suffix to find out the true root of the workspace.
+                // It's not safe to run `bazel info workspace` here because for some reason
+                // it sometimes returns the wrong folder. Not sure if it's the Swift extension
+                // causing that or Cursor, but it ended up being safer to look at the actual process's path.
+                return URL(fileURLWithPath: processInfoPath)
+                    .deletingLastPathComponent()
+                    .deletingLastPathComponent()
+                    .path
+            } else {
+                return nil
+            }
+        }()
         let kindsQuery = "\"" + rules.map { $0.rawValue }.joined(separator: "|") + "\""
         let locationsQuery = locations.joined(separator: " union ")
         let query = "kind(\(kindsQuery), \(locationsQuery))"
@@ -56,7 +73,7 @@ public enum BazelTargetDiscoverer {
         }()
         let cmd = "\(bazelWrapper) cquery '\(query)'\(additionalFlagsString) --output label"
 
-        let output: String = try commandRunner.run(cmd)
+        let output: String = try commandRunner.run(cmd, cwd: cwd)
 
         let discoveredTargets =
             output

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -144,7 +144,7 @@ final class InitializeHandler {
     }
 
     func getSDKRootPaths(with commandRunner: CommandRunner) -> [String: String] {
-        let supportedSDKTypes = Set(TopLevelRuleType.allCases.map { $0.sdkName }).sorted()
+        let supportedSDKTypes = Set(baseConfig.topLevelRulesToDiscover.map { $0.sdkName }).sorted()
         let sdkRootPaths: [String: String] = supportedSDKTypes.reduce(into: [:]) { result, sdkType in
             // This will fail if the user doesn't have the SDK installed, which is fine.
             guard let sdkRootPath: String? = try? commandRunner.run("xcrun --sdk \(sdkType) --show-sdk-path") else {

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -30,6 +30,7 @@ package struct BaseServerConfig: Equatable {
     let indexFlags: [String]
     let filesToWatch: String?
     let compileTopLevel: Bool
+    let topLevelRulesToDiscover: [TopLevelRuleType]
 
     package init(
         bazelWrapper: String,
@@ -37,11 +38,13 @@ package struct BaseServerConfig: Equatable {
         indexFlags: [String],
         filesToWatch: String?,
         compileTopLevel: Bool,
+        topLevelRulesToDiscover: [TopLevelRuleType],
     ) {
         self.bazelWrapper = bazelWrapper
         self.indexFlags = indexFlags
         self.filesToWatch = filesToWatch
         self.compileTopLevel = compileTopLevel
+        self.topLevelRulesToDiscover = topLevelRulesToDiscover
 
         // We need to post-process the target list provided by the user
         // because the queries will always return the "full" label.

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -38,7 +38,7 @@ package struct BaseServerConfig: Equatable {
         indexFlags: [String],
         filesToWatch: String?,
         compileTopLevel: Bool,
-        topLevelRulesToDiscover: [TopLevelRuleType],
+        topLevelRulesToDiscover: [TopLevelRuleType] = TopLevelRuleType.allCases,
     ) {
         self.bazelWrapper = bazelWrapper
         self.indexFlags = indexFlags

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -48,7 +48,7 @@ struct Serve: ParsableCommand {
     @Option(
         parsing: .singleValue,
         help:
-            "A top-level rule type to discover targets for (e.g. 'ios_application', 'ios_unit_test'). Can be specified multiple times. Only applicable when not passing --target directly. If not specified, all supported top-level rule types will be used for target discovery."
+            "A top-level rule type to discover targets for (e.g. 'ios_application', 'ios_unit_test'). Can be specified multiple times. If not specified, all supported top-level rule types will be used for target discovery."
     )
     var topLevelRuleToDiscover: [TopLevelRuleType] = []
 
@@ -132,7 +132,6 @@ struct Serve: ParsableCommand {
                 bazelWrapper: bazelWrapper,
                 locations: targets,
                 additionalFlags: indexFlags,
-                processInfoPath: ProcessInfo.processInfo.arguments.first ?? ""
             )
         } catch {
             logger.error(

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -61,6 +61,12 @@ struct Serve: ParsableCommand {
     func run() throws {
         logger.info("`serve` invoked, initializing BSP server...")
 
+        let rulesToUse: [TopLevelRuleType]
+        if !topLevelRuleToDiscover.isEmpty {
+            rulesToUse = topLevelRuleToDiscover
+        } else {
+            rulesToUse = TopLevelRuleType.allCases
+        }
         let indexFlags = indexFlag.map { "--" + $0 }
         let targets: [String]
         if !target.isEmpty {
@@ -78,7 +84,7 @@ struct Serve: ParsableCommand {
                     contentsOf: try expandWildcardTargets(
                         bazelWrapper: bazelWrapper,
                         targets: targetsToExpand,
-                        topLevelRuleToDiscover: topLevelRuleToDiscover,
+                        topLevelRuleToDiscover: rulesToUse,
                         indexFlags: indexFlags
                     )
                 )
@@ -90,7 +96,7 @@ struct Serve: ParsableCommand {
             targets = try expandWildcardTargets(
                 bazelWrapper: bazelWrapper,
                 targets: ["..."],
-                topLevelRuleToDiscover: topLevelRuleToDiscover,
+                topLevelRuleToDiscover: rulesToUse,
                 indexFlags: indexFlags
             )
         }
@@ -100,7 +106,8 @@ struct Serve: ParsableCommand {
             targets: targets,
             indexFlags: indexFlags,
             filesToWatch: filesToWatch,
-            compileTopLevel: compileTopLevel
+            compileTopLevel: compileTopLevel,
+            topLevelRulesToDiscover: rulesToUse
         )
 
         logger.debug("Initializing BSP with targets: \(targets)")
@@ -119,18 +126,13 @@ struct Serve: ParsableCommand {
         logger.warning(
             "Will expand wildcard targets (\(targetsString, privacy: .public)). This can cause the BSP to perform poorly if we find too many targets. Prefer passing explicit targets via --targets if possible."
         )
-        let rulesToUse: [TopLevelRuleType]
-        if !topLevelRuleToDiscover.isEmpty {
-            rulesToUse = topLevelRuleToDiscover
-        } else {
-            rulesToUse = TopLevelRuleType.allCases
-        }
         do {
             return try BazelTargetDiscoverer.discoverTargets(
-                for: rulesToUse,
+                for: topLevelRuleToDiscover,
                 bazelWrapper: bazelWrapper,
                 locations: targets,
-                additionalFlags: indexFlags
+                additionalFlags: indexFlags,
+                processInfoPath: ProcessInfo.processInfo.arguments.first ?? ""
             )
         } catch {
             logger.error(

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -114,7 +114,7 @@ setup_sourcekit_bsp = rule(
             default = [],
         ),
         "top_level_rules_to_discover": attr.string_list(
-            doc = "A list of top-level rule types to discover targets for (e.g. 'ios_application', 'ios_unit_test'). Only applicable when not specifying targets directly. If not specified, all supported top-level rule types will be used for target discovery.",
+            doc = "A list of top-level rule types to discover targets for (e.g. 'ios_application', 'ios_unit_test'). If not specified, all supported top-level rule types will be used for target discovery.",
             default = [],
         ),
         "index_build_batch_size": attr.int(


### PR DESCRIPTION
--top-level-rule-to-discover was only applying for the initial discover step, but it should also apply to the eventual cquery/aquery commands we execute.