### PR TITLE
Add base simulator handling logic to the Example app

### DIFF
--- a/Example/.vscode/tasks.json
+++ b/Example/.vscode/tasks.json
@@ -2,55 +2,33 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Build HelloWorld",
+      "label": "Select Simulator for Apple Development",
       "type": "shell",
-      "command": "bazelisk",
-      "args": [
-        "build",
-        "//HelloWorld"
-      ],
-      "group": {
-        "kind": "build",
-        "isDefault": true
+      "command": "./scripts/select_simulator.sh",
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "dedicated"
       },
-      "problemMatcher": [
-        {
-          "owner": "swift",
-          "source": "swift",
-          "fileLocation": [
-            "relative",
-            "${workspaceFolder}"
-          ],
-          "pattern": {
-            "regexp": "^(.+?):(\\d+):(\\d+):\\s+(error|warning|note):\\s+(.*)$",
-            "file": 1,
-            "line": 2,
-            "column": 3,
-            "severity": 4,
-            "message": 5
-          }
-        },
-      ],
-      "runOptions": {
-        "instanceLimit": 1
-      }
+      "problemMatcher": []
     },
     {
-      "label": "Test HelloWorldTests",
+      "label": "Build HelloWorld",
       "type": "shell",
-      "command": "bazelisk",
-      "args": [
-        "test",
-        "//HelloWorld:HelloWorldTests"
-      ],
+      "command": "./scripts/lldb_build.sh",
+      "options": {
+        "env": {
+          "BAZEL_LABEL_TO_RUN": "//HelloWorld:HelloWorld",
+          "BAZEL_EXTRA_BUILD_FLAGS": "",
+        }
+      },
       "group": {
-        "kind": "test",
-        "isDefault": true
+        "kind": "build",
       },
       "problemMatcher": [
         {
-          "owner": "swift",
-          "source": "swift",
+          "owner": "bazelisk",
+          "source": "bazelisk",
           "fileLocation": [
             "relative",
             "${workspaceFolder}"
@@ -62,12 +40,9 @@
             "column": 3,
             "severity": 4,
             "message": 5
-          }
+          },
         },
       ],
-      "runOptions": {
-        "instanceLimit": 1
-      }
     },
     // Hidden never-ending task that handles the launch / debugging bits for Cmd+Shift+D.
     // The problemMatcher field defines when the task is effectively ready to be debugged
@@ -78,7 +53,9 @@
       "command": "./scripts/lldb_launch_and_debug.sh",
       "options": {
         "env": {
-          "BAZEL_LABEL_TO_RUN": "//HelloWorld:HelloWorld"
+          "BAZEL_LABEL_TO_RUN": "//HelloWorld:HelloWorld",
+          "BAZEL_EXTRA_BUILD_FLAGS": "",
+          "BAZEL_LAUNCH_ARGS": ""
         }
       },
       "presentation": {
@@ -88,40 +65,49 @@
       "isBackground": true,
       "problemMatcher": [
         {
-          "owner": "swift",
-          "source": "swift",
+          "owner": "bazelisk",
+          "source": "bazelisk",
           "fileLocation": [
             "relative",
             "${workspaceFolder}"
           ],
           "pattern": {
-            "regexp": "^(.+?):(\\d+):(\\d+):\\s+(error|warning|note):\\s+(.*)$",
-            "file": 1,
-            "line": 2,
-            "column": 3,
-            "severity": 4,
-            "message": 5
+              "regexp": "launcher_error in (.*): (.*)",
+              "kind": "file",
+              "file": 1,
+              "message": 2,
+          },
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "^Starting launch task\\.\\.\\.$",
+            "endsPattern": "^.*Launched with PID: .*"
           }
         },
         {
-          "pattern": [
-            {
-              "regexp": "\\b\\B",
-              "file": 1,
-              "location": 2,
-              "message": 3
-            }
+          "owner": "bazelisk",
+          "source": "bazelisk",
+          "fileLocation": [
+            "relative",
+            "${workspaceFolder}"
           ],
+          "pattern": {
+              "regexp": "^(.+?):(\\d+):(\\d+):\\s+(error|warning|note):\\s+(.*)$",
+              "file": 1,
+              "line": 2,
+              "column": 3,
+              "severity": 4,
+              "message": 5
+          },
           "background": {
             "activeOnStart": true,
-            "beginsPattern": "^.*Building .*",
+            "beginsPattern": "^Starting launch task\\.\\.\\.$",
             "endsPattern": "^.*Launched with PID: .*"
           }
-        }
+        },
       ],
       "runOptions": {
         "instanceLimit": 1
       }
-    }
+    },
   ]
 }

--- a/Example/README.md
+++ b/Example/README.md
@@ -1,13 +1,14 @@
 # Example (Cursor/VSCode)
 
-This is a simple **iOS** app that lets you see sourcekit-bazel-bsp in action. This example and instructions were designed specifically for **Cursor**, but should also work for VSCode.
+This is a simple collection of iOS/watchOS/macOS apps that lets you see sourcekit-bazel-bsp in action. This example and instructions were designed specifically for **Cursor**, but should also work for VSCode.
 
 ## Initial Setup Instructions
 
 - Make sure you fulfill the toolchain requirements for sourcekit-bazel-bsp, available at the main README.
-- Install [bazelisk](https://github.com/bazelbuild/bazelisk) if you haven't already.
-  - On macOS: `brew install bazelisk`
+- Install [bazelisk](https://github.com/bazelbuild/bazelisk) if you haven't already: `brew install bazelisk`
   - Make sure you're using **Xcode 26** as this is what this project was developed with.
+- Install [fzf](https://github.com/junegunn/fzf) if you haven't already: `brew install fzf`
+  - This is used to power the simulator selection features.
 - On this folder, run:
   - `bazelisk run //HelloWorld:setup_sourcekit_bsp_example_project`
 - (Optional) Follow the instructions from the main README regarding configuring a custom SourceKit-LSP binary.
@@ -17,12 +18,12 @@ This is a simple **iOS** app that lets you see sourcekit-bazel-bsp in action. Th
 
 After performing these steps, you should already be able to see the basic indexing features in action. It may take a minute or two the first time, but you can see the progress at the bottom of the IDE. You should also be able to see a new `SourceKit Language Server` option on the `Output` tab that shows sourcekit-lsp's internal logs, and after modifying a file for the first time an additional `SourceKit-LSP: Indexing` tab will pop up containing more detailed logs from both tools.
 
-## Building and Testing
+## Building and Debugging
 
-- To run a regular build: Cmd+Shift+B -> `Build HelloWorld`
-- To run a debug build, launch the simulator and attach `lldb`: Cmd+Shift+D -> `Debug HelloWorld (Example)`
-  - This requires a **iOS 18.6 iPhone 16 Pro** simulator installed as this is what the example project is currently configured for. Make sure you have one available, as otherwise the build will fail.
-- To test: Cmd+Shift+P -> `Run Test Task` -> `Test HelloWorldTests`
+- To build the example iOS app: `Terminal` -> `Run Build Task...` -> `Build HelloWorld`
+- To run a debug build, launch a simulator and attach `lldb`:
+  - First, select an appropriate iOS simulator via `Terminal` -> `Run Task...` -> `Select Simulator for Apple Development`. The minimum OS version of the example app is **iOS 17.0**.
+  - Then: Cmd+Shift+D -> `Debug HelloWorld (Example)`. After building, the IDE will automatically launch your selected simulator and attach it to the IDE's lldb extension.
 
 ## Considerations
 

--- a/Example/scripts/lldb_build.sh
+++ b/Example/scripts/lldb_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source "scripts/lldb_build_common.sh"
+run_bazel "build"

--- a/Example/scripts/lldb_build_common.sh
+++ b/Example/scripts/lldb_build_common.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Stores common functionality for build and launch tasks.
+
+set -e
+
+export WORKSPACE_ROOT
+WORKSPACE_ROOT=$(pwd)
+
+export ADDITIONAL_FLAGS=()
+ADDITIONAL_FLAGS+=("--keep_going")
+ADDITIONAL_FLAGS+=("--color=yes")
+
+if [ -n "${BAZEL_EXTRA_BUILD_FLAGS:-}" ]; then
+  ADDITIONAL_FLAGS+=("${BAZEL_EXTRA_BUILD_FLAGS[@]}")
+fi
+
+LAUNCH_ARGS_ARRAY=()
+if [ -n "${BAZEL_LAUNCH_ARGS:-}" ]; then
+  read -ra LAUNCH_ARGS_ARRAY <<< "$BAZEL_LAUNCH_ARGS"
+fi
+
+function run_bazel() {
+  local command="$1"
+  bazelisk "${command}" "${BAZEL_LABEL_TO_RUN}" "${ADDITIONAL_FLAGS[@]}" ${LAUNCH_ARGS_ARRAY[@]:+-- "${LAUNCH_ARGS_ARRAY[@]}"}
+}

--- a/Example/scripts/select_simulator.sh
+++ b/Example/scripts/select_simulator.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+# Script that displays all available simulators to the user
+# and writes the selected one's UUID to a file. This file
+# is then parsed by lldb_launch_and_debug.sh to pass the
+# appropriate device flags to Bazel.
+
+WORKSPACE_ROOT=$(pwd)
+OUTPUT_FILE=${WORKSPACE_ROOT}/.bsp/skbsp_generated/simulator_info.txt
+
+# Get list of all available simulators with their UDIDs
+# Format: "Device Name (platform X.Y) - UDID"
+SIMULATORS=$(xcrun simctl list devices available -j | jq -r '
+  .devices | to_entries[] |
+  .key as $runtime |
+  .value[] |
+  ($runtime | split("SimRuntime.")[1] | split("-") | "\(.[0]) \(.[1]).\(.[2])") as $version |
+  "\(.name) (\($version)) - \(.udid)"
+' | sort)
+
+if [ -z "$SIMULATORS" ]; then
+  echo "error: No available simulators found."
+  exit 1
+fi
+
+# Check if fzf is available
+if ! command -v fzf &> /dev/null; then
+  echo "error: You need \`fzf\` to run this script. You can install it with 'brew install fzf'."
+  exit 1
+fi
+
+SELECTED=$(echo "$SIMULATORS" | fzf --height=20 --reverse --prompt="Select the simulator you'd like to use: ")
+
+if [ -z "$SELECTED" ]; then
+  echo "error: No simulator selected."
+  exit 1
+fi
+
+# Extract the UUID from the selection (split(" - ")[1])
+UUID=$(echo "$SELECTED" | awk -F' - ' '{print $2}')
+
+mkdir -p "$(dirname "$OUTPUT_FILE")" || true
+echo -n "$UUID" > "$OUTPUT_FILE"
+
+echo "Selected simulator: $SELECTED"
+echo "UUID ($UUID) successfully written to: $OUTPUT_FILE"
+echo "The selected simulator will now be used for your future builds."

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - [x] All of the usual indexing features such as code completion, jump to definition, error annotations and so on, for both Swift and Obj-C (via the official [sourcekit-lsp](https://github.com/swiftlang/sourcekit-lsp))
 - [x] (Cursor / VSCode): Building and launching, all from within the IDE and directly via Bazel (no project generation required!)
 - [x] (Cursor / VSCode): Full `lldb` integration, allowing debugging from within the IDE just like Xcode (via [lldb-dap](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.lldb-dap), automatically provided by the official Swift extension)
-- [ ] (Cursor / VSCode): Simulator selection from within the IDE
+- [x] (Cursor / VSCode): Simulator selection from within the IDE (via custom IDE tasks)
 - [ ] (Cursor / VSCode): Automatic generation of build, launch, and debug tasks
 - [ ] (Cursor / VSCode): Test explorer & ability to run tests from within the IDE by clicking the tests individually, similarly to Xcode
 - [ ] Automatic index and build graph updates when adding / deleting files and targets (in other words, allowing the user to make heavy changes to the project without needing to restart the IDE)
@@ -75,6 +75,12 @@ The setup instructions depend on how the IDE integrates with LSPs. You should th
 The BSP by default works by attempting to build your library targets individually with a set of platform flags based on the library's parent app, which is an action that currently does not share action cache keys with the compilation of the apps themselves. If your goal is to have index builds share cache with regular app builds, this would mean that as of writing you would end up with two sets of artifacts.
 
 If this is undesirable, you can pass the `--compile-top-level` flag to make the BSP compile the target's **parent** instead, without any special flags. We recommend using this for projects that define fine-grained `*_build_test` targets and providing them as top-level targets for the BSP, as those don't suffer from this issue and thus enables maximum predictability and cacheability.
+
+## Best Practices
+
+- When working with large apps, consider being more explicit about the task you're going to do. This means that instead of importing the _entire app at all times_, try to import only a small group of test targets that you think will be required to perform the task. This will greatly increase the performance of the IDE.
+    - For smaller apps, this doesn't make much difference and it should be fine to import the entire app.
+- Similarly, avoid wide-reaching wildcards like `//...`. Do so only at a smaller scale to avoid too many targets from being picked up.
 
 ## Troubleshooting
 


### PR DESCRIPTION
- Adds a new VSCode task for selecting simulators
- Remove the test task for now (will re-introduce later on)
- The LLDB launch script can now handle deleting lldbinit files from rules_xcodeproj if needed.
- The build task script now also supports additional flags via envs
- The LLDB launch script can now handle reading simulator info from a file
- Expands how the problemMatchers are defined to make the IDE slightly better at detecting and reporting errors when compilation fails