### PR TITLE
Remove task progress from the SKOptions request

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/SKOptionsHandler.swift
@@ -56,17 +56,14 @@ final class SKOptionsHandler {
         _ request: TextDocumentSourceKitOptionsRequest,
         _ id: RequestID
     ) throws -> TextDocumentSourceKitOptionsResponse? {
-        let taskId = TaskId(id: "getSKOptions-\(id.description)")
-        connection?.startWorkTask(id: taskId, title: "sourcekit-bazel-bsp: Fetching compiler arguments...")
+        // This request doesn't publish a task progress report to the IDE because it's very spammy.
         do {
             let result = try stateLock.withLockUnchecked {
                 let result = try handle(request: request)
-                connection?.finishTask(id: taskId, status: .ok)
                 return result
             }
             return result
         } catch {
-            connection?.finishTask(id: taskId, status: .error)
             throw error
         }
     }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
@@ -55,7 +55,7 @@ final class TargetSourcesHandler {
         let count = srcs.reduce(0) { $0 + $1.sources.count }
 
         logger.info(
-            "Returning \(srcs.count, privacy: .public) source specs (\(count, privacy: .public) total source entries"
+            "Returning \(srcs.count, privacy: .public) source specs (\(count, privacy: .public) total source entries)"
         )
 
         return BuildTargetSourcesResponse(items: srcs)


### PR DESCRIPTION
This request is sent ~10x per second, making the IDE very spammy. Think it should be fine to skip this one.