### PR TITLE
Add support for using only one output base

### DIFF
--- a/Example/HelloWorld/BUILD
+++ b/Example/HelloWorld/BUILD
@@ -286,4 +286,5 @@ setup_sourcekit_bsp(
         "//HelloWorld/...",
     ],
     merge_lsp_config = False,
+    experimental_no_extra_output_base = True
 )

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -97,9 +97,16 @@ final class InitializeHandler {
 
         // Setup the special output base path where we will run indexing commands from.
         // Nesting into a subfolder for easier cleanup. For example: /private/var/tmp/_bazel_<User>/<ProjectHash>/sourcekit-bazel-bsp
-        let outputBase = regularOutputBase.appendingPathComponent(
-            "sourcekit-bazel-bsp"
-        ).path
+        let outputBase: String
+        if baseConfig.noExtraOutputBase {
+            outputBase = regularOutputBase.path
+            logger.debug("Will use the regular output base for all actions")
+        } else {
+            outputBase =
+                regularOutputBase.appendingPathComponent(
+                    "sourcekit-bazel-bsp"
+                ).path
+        }
         logger.debug("outputBase: \(outputBase, privacy: .public)")
 
         // Now, get the full output path based on the above output base.

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -37,6 +37,7 @@ package struct BaseServerConfig: Equatable {
     let topLevelTargetsToExclude: [String]
     let dependencyTargetsToExclude: [String]
     let appleSupportRepoName: String
+    let noExtraOutputBase: Bool
 
     package init(
         bazelWrapper: String,
@@ -50,7 +51,8 @@ package struct BaseServerConfig: Equatable {
         dependencyRulesToDiscover: [DependencyRuleType] = DependencyRuleType.allCases,
         topLevelTargetsToExclude: [String] = [],
         dependencyTargetsToExclude: [String] = [],
-        appleSupportRepoName: String = "apple_support"
+        appleSupportRepoName: String = "apple_support",
+        noExtraOutputBase: Bool = false
     ) {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
@@ -64,5 +66,6 @@ package struct BaseServerConfig: Equatable {
         self.topLevelTargetsToExclude = topLevelTargetsToExclude
         self.dependencyTargetsToExclude = dependencyTargetsToExclude
         self.appleSupportRepoName = appleSupportRepoName
+        self.noExtraOutputBase = noExtraOutputBase
     }
 }

--- a/Sources/SourceKitBazelBSP/SharedUtils/Shell/CommandRunner.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/Shell/CommandRunner.swift
@@ -101,7 +101,8 @@ extension CommandRunner {
         } else {
             startupFlagsString = " " + additionalStartupFlags.joined(separator: " ")
         }
-        return "--output_base=\(outputBase)\(startupFlagsString) \(cmd)\(flagsString)"
+        let outputBasePrefix = baseConfig.noExtraOutputBase ? "" : "--output_base=\(outputBase)"
+        return "\(outputBasePrefix)\(startupFlagsString) \(cmd)\(flagsString)"
     }
 
     /// A regular bazel command, but at this BSP's special output base and taking into account the special index flags.

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -99,7 +99,13 @@ struct Serve: AsyncParsableCommand {
     )
     var appleSupportRepoName: String = "apple_support"
 
-    func run() async throws {
+    @Flag(
+        help:
+            "(EXPERIMENTAL) If enabled, the BSP will not create a separate output base for its indexing actions. Can greatly reduce disk usage and improve cache hits at the cost of more pressure on the single Bazel server."
+    )
+    var experimentalNoExtraOutputBase: Bool = false
+
+    func run() throws {
         logger.info("`serve` invoked, initializing BSP server...")
 
         let topLevelRulesToDiscover: [TopLevelRuleType] =
@@ -123,7 +129,8 @@ struct Serve: AsyncParsableCommand {
             dependencyRulesToDiscover: dependencyRulesToDiscover,
             topLevelTargetsToExclude: topLevelTargetToExclude,
             dependencyTargetsToExclude: dependencyTargetToExclude,
-            appleSupportRepoName: appleSupportRepoName
+            appleSupportRepoName: appleSupportRepoName,
+            noExtraOutputBase: experimentalNoExtraOutputBase
         )
 
         logger.debug("Initializing BSP with targets: \(targets)")

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -45,6 +45,8 @@ def _setup_sourcekit_bsp_impl(ctx):
     if ctx.attr.apple_support_repo_name:
         bsp_config_argv.append("--apple-support-repo-name")
         bsp_config_argv.append(ctx.attr.apple_support_repo_name)
+    if ctx.attr.experimental_no_extra_output_base:
+        bsp_config_argv.append("--experimental-no-extra-output-base")
     ctx.actions.expand_template(
         template = ctx.file._bsp_config_template,
         output = rendered_bsp_config,
@@ -77,6 +79,7 @@ def _setup_sourcekit_bsp_impl(ctx):
     ctx.actions.write(rendered_lsp_config, json.encode_indent(lsp_config_json, indent = "  "))
 
     merge_lsp_config_env = "1" if ctx.attr.merge_lsp_config else ""
+    no_extra_output_base_env = "1" if ctx.attr.experimental_no_extra_output_base else ""
 
     # Generating the script that ties everything together
     executable = ctx.actions.declare_file("setup_sourcekit_bsp.sh")
@@ -89,7 +92,8 @@ def _setup_sourcekit_bsp_impl(ctx):
             "%lsp_config_path%": rendered_lsp_config.short_path,
             "%sourcekit_bazel_bsp_path%": ctx.executable.sourcekit_bazel_bsp.short_path,
             "%merge_lsp_config_env%": merge_lsp_config_env,
-            "%bazel_wrapper%": ctx.attr.bazel_wrapper
+            "%bazel_wrapper%": ctx.attr.bazel_wrapper,
+            "%no_extra_output_base_env%": no_extra_output_base_env
         },
     )
     tools_runfiles = ctx.runfiles(
@@ -187,6 +191,10 @@ setup_sourcekit_bsp = rule(
         "merge_lsp_config": attr.bool(
             doc = "If set to true, the generated .sourcekit-lsp/config.json will merge with any existing contents instead of fully overriding the file.",
             default = True,
+        ),
+        "experimental_no_extra_output_base": attr.bool(
+            doc = "(EXPERIMENTAL) If enabled, the BSP will not create a separate output base for its indexing actions. Can greatly reduce disk usage and improve cache hits at the cost of more pressure on the single Bazel server.",
+            default = False,
         ),
     },
 )

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -13,6 +13,7 @@ sourcekit_bazel_bsp_path="%sourcekit_bazel_bsp_path%"
 bsp_config_path="%bsp_config_path%"
 lsp_config_path="%lsp_config_path%"
 bazel_wrapper="%bazel_wrapper%"
+no_extra_output_base_env="%no_extra_output_base_env%"
 
 bsp_folder_path="$BUILD_WORKSPACE_DIRECTORY/.bsp"
 lsp_folder_path="$BUILD_WORKSPACE_DIRECTORY/.sourcekit-lsp"
@@ -167,7 +168,11 @@ exec_root=$(cd "$WORKSPACE_ROOT" && $bazel_wrapper info execution_root)
 exec_root_difference=$(echo "$exec_root" | sed "s|$output_base/||")
 output_path_name=$(echo "$output_path" | sed "s|$exec_root/||")
 old_bsp_output_base="${output_base}-sourcekit-bazel-bsp"
-bsp_output_base="${output_base}/sourcekit-bazel-bsp"
+if [ "$no_extra_output_base_env" = "1" ]; then
+    bsp_output_base="${output_base}"
+else
+    bsp_output_base="${output_base}/sourcekit-bazel-bsp"
+fi
 output_path="${bsp_output_base}/${output_path_difference}"
 external_root="${bsp_output_base}/${exec_root_difference}/external"
 


### PR DESCRIPTION
The issue with using a separate output base is that we cannot make good use of `index while building`. This PR then adds an options for everything to happen on a single output base to enable regular build actions to pre-populate the index for us.

WIP: Still trying to understand which particular setup (compile_top_level, etc) results in the strongest gain and whether or not sourcekit-lsp behaves correctly when requests are cancelled.

(On hold: Want to try solving the root issue with output groups first)