### PR TITLE
Handle Xcode envs when passing arguments manually

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -111,10 +111,14 @@ final class InitializeHandler {
 
         // Collecting the rest of the env's details
         let devDir: String = try commandRunner.run("xcode-select --print-path")
+        let xcodeVersion: String = try commandRunner.run(
+            "xcodebuild -version | grep 'Build version' | awk '{print $3}'"
+        )
         let toolchain = try getToolchainPath(with: commandRunner)
         let sdkRootPaths: [String: String] = getSDKRootPaths(with: commandRunner)
 
         logger.debug("devDir: \(devDir, privacy: .public)")
+        logger.debug("xcodeVersion: \(xcodeVersion, privacy: .public)")
         logger.debug("toolchain: \(toolchain, privacy: .public)")
         logger.debug("sdkRootPaths: \(sdkRootPaths, privacy: .public)")
 
@@ -124,6 +128,7 @@ final class InitializeHandler {
             outputBase: outputBase,
             outputPath: outputPath,
             devDir: devDir,
+            xcodeVersion: xcodeVersion,
             devToolchainPath: toolchain,
             executionRoot: executionRoot,
             sdkRootPaths: sdkRootPaths

--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -106,6 +106,8 @@ final class PrepareHandler {
                         minimumOsVersion: labelToBuild.topLevelParentConfig.minimumOsVersion,
                         platform: labelToBuild.topLevelParentConfig.platform,
                         cpuArch: labelToBuild.topLevelParentConfig.cpuArch,
+                        devDir: initializedConfig.devDir,
+                        xcodeVersion: initializedConfig.xcodeVersion
                     )
                     argsToLabelsMap[args, default: []].append(labelToBuild.label)
                 }
@@ -196,7 +198,9 @@ final class PrepareHandler {
     func buildArgs(
         minimumOsVersion: String,
         platform: String,
-        cpuArch: String
+        cpuArch: String,
+        devDir: String,
+        xcodeVersion: String
     ) -> [String] {
         // As of writing, Bazel does not provides a "build X as if it were a child of Y" flag.
         // This means that to compile individual libraries accurately, we need to replicate
@@ -226,6 +230,10 @@ final class PrepareHandler {
             "--\(friendlyPlatName)_minimum_os=\"\(minimumOsVersion)\"",
             "--cpu=\(platform)_\(cpuArch)",
             "--minimum_os_version=\"\(minimumOsVersion)\"",
+            "--xcode_version=\"\(xcodeVersion)\"",
+            "--repo_env=DEVELOPER_DIR=\"\(devDir)\"",
+            "--repo_env=USE_CLANG_CL=\"\(xcodeVersion)\"",
+            "--repo_env=XCODE_VERSION=\"\(xcodeVersion)\"",
         ]
     }
 

--- a/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
@@ -27,6 +27,7 @@ struct InitializedServerConfig: Equatable {
     let outputBase: String
     let outputPath: String
     let devDir: String
+    let xcodeVersion: String
     let devToolchainPath: String
     let executionRoot: String
     let sdkRootPaths: [String: String]

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -54,6 +54,7 @@ struct BazelTargetCompilerArgsExtractorTests {
         let mockSdkRootPaths = [
             "iphonesimulator": iosSimSdk
         ]
+        let mockXcodeVersion = "17B100"
         let config = InitializedServerConfig(
             baseConfig: BaseServerConfig(
                 bazelWrapper: "bazel",
@@ -66,6 +67,7 @@ struct BazelTargetCompilerArgsExtractorTests {
             outputBase: mockOutputBase,
             outputPath: mockOutputPath,
             devDir: mockDevDir,
+            xcodeVersion: mockXcodeVersion,
             devToolchainPath: mockDevToolchainPath,
             executionRoot: mockExecRoot,
             sdkRootPaths: mockSdkRootPaths

--- a/Tests/SourceKitBazelBSPTests/BazelTargetParserTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetParserTests.swift
@@ -41,6 +41,7 @@ struct BazelTargetParserTests {
             outputBase: "/path/to/output/base",
             outputPath: "/path/to/output/path",
             devDir: "/path/to/dev/dir",
+            xcodeVersion: "17B100",
             devToolchainPath: "/path/to/toolchain",
             executionRoot: "/path/to/execution/root",
             sdkRootPaths: ["iphonesimulator": "/path/to/sdk/root"]

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -46,6 +46,7 @@ struct BazelTargetQuerierTests {
             outputBase: "/path/to/output/base",
             outputPath: "/path/to/output/path",
             devDir: "/path/to/dev/dir",
+            xcodeVersion: "17B100",
             devToolchainPath: "/path/to/toolchain",
             executionRoot: "/path/to/execution/root",
             sdkRootPaths: ["iphonesimulator": "/path/to/sdk/root"]
@@ -89,6 +90,7 @@ struct BazelTargetQuerierTests {
             outputBase: "/path/to/output/base",
             outputPath: "/path/to/output/path",
             devDir: "/path/to/dev/dir",
+            xcodeVersion: "17B100",
             devToolchainPath: "/path/to/toolchain",
             executionRoot: "/path/to/execution/root",
             sdkRootPaths: ["iphonesimulator": "/path/to/sdk/root"]
@@ -132,6 +134,7 @@ struct BazelTargetQuerierTests {
             outputBase: "/path/to/output/base",
             outputPath: "/path/to/output/path",
             devDir: "/path/to/dev/dir",
+            xcodeVersion: "17B100",
             devToolchainPath: "/path/to/toolchain",
             executionRoot: "/path/to/execution/root",
             sdkRootPaths: ["iphonesimulator": "/path/to/sdk/root"]
@@ -196,6 +199,7 @@ struct BazelTargetQuerierTests {
             outputBase: "/path/to/output/base",
             outputPath: "/path/to/output/path",
             devDir: "/path/to/dev/dir",
+            xcodeVersion: "17B100",
             devToolchainPath: "/path/to/toolchain",
             executionRoot: "/path/to/execution/root",
             sdkRootPaths: ["iphonesimulator": "/path/to/sdk/root"]

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -44,6 +44,7 @@ struct InitializeHandlerTests {
         let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let executionRoot = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main"
         let devDir = "/Applications/Xcode.app/Contents/Developer"
+        let xcodeVersion: String = "17B100"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
@@ -58,6 +59,10 @@ struct InitializeHandlerTests {
             response: executionRoot
         )
         commandRunner.setResponse(for: "xcode-select --print-path", response: devDir)
+        commandRunner.setResponse(
+            for: "xcodebuild -version | grep 'Build version' | awk '{print $3}'",
+            response: xcodeVersion
+        )
         commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
         commandRunner.setResponse(for: "xcrun --sdk iphonesimulator --show-sdk-path", response: "sdkiossim")
 
@@ -75,6 +80,7 @@ struct InitializeHandlerTests {
                     outputBase: outputBase + "-sourcekit-bazel-bsp",
                     outputPath: outputPath,
                     devDir: devDir,
+                    xcodeVersion: xcodeVersion,
                     devToolchainPath: toolchain,
                     executionRoot: executionRoot,
                     sdkRootPaths: ["iphonesimulator": "sdkiossim"]
@@ -98,6 +104,7 @@ struct InitializeHandlerTests {
         let outputBase = "/_bazel_user/abc123"
         let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
+        let xcodeVersion: String = "17B100"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
         commandRunner.setResponse(
@@ -113,6 +120,10 @@ struct InitializeHandlerTests {
         commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
         commandRunner.setResponse(for: "xcode-select --print-path", response: "foo")
         commandRunner.setResponse(for: "xcrun --sdk iphonesimulator --show-sdk-path", response: "bar")
+        commandRunner.setResponse(
+            for: "xcodebuild -version | grep 'Build version' | awk '{print $3}'",
+            response: xcodeVersion
+        )
 
         let handler = InitializeHandler(baseConfig: baseConfig, commandRunner: commandRunner)
 
@@ -139,6 +150,7 @@ struct InitializeHandlerTests {
         let outputBase = "/_bazel_user/abc123"
         let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
+        let xcodeVersion: String = "17B100"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
         commandRunner.setResponse(
@@ -156,6 +168,10 @@ struct InitializeHandlerTests {
         commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
         commandRunner.setResponse(for: "xcode-select --print-path", response: "foo")
         commandRunner.setResponse(for: "xcrun --sdk iphonesimulator --show-sdk-path", response: "bar")
+        commandRunner.setResponse(
+            for: "xcodebuild -version | grep 'Build version' | awk '{print $3}'",
+            response: xcodeVersion
+        )
 
         let handler = InitializeHandler(baseConfig: baseConfig, commandRunner: commandRunner)
 

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -46,6 +46,7 @@ struct PrepareHandlerTests {
             outputBase: "/tmp/output_base",
             outputPath: "/tmp/output_path",
             devDir: "/Applications/Xcode.app/Contents/Developer",
+            xcodeVersion: "17B100",
             devToolchainPath: "/a/b/XcodeDefault.xctoolchain/",
             executionRoot: "/tmp/output_path/execroot/_main",
             sdkRootPaths: ["iphonesimulator": "bar"]
@@ -135,7 +136,9 @@ struct PrepareHandlerTests {
         let actualFlags = handler.buildArgs(
             minimumOsVersion: "15.0",
             platform: "ios",
-            cpuArch: "arm64"
+            cpuArch: "arm64",
+            devDir: "/Applications/Xcode.app/Contents/Developer",
+            xcodeVersion: "17B100"
         )
         #expect(
             actualFlags == [
@@ -146,6 +149,10 @@ struct PrepareHandlerTests {
                 "--ios_minimum_os=\"15.0\"",
                 "--cpu=ios_arm64",
                 "--minimum_os_version=\"15.0\"",
+                "--xcode_version=\"17B100\"",
+                "--repo_env=DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\"",
+                "--repo_env=USE_CLANG_CL=\"17B100\"",
+                "--repo_env=XCODE_VERSION=\"17B100\"",
             ]
         )
     }
@@ -155,7 +162,9 @@ struct PrepareHandlerTests {
         let actualFlags = handler.buildArgs(
             minimumOsVersion: "15.0",
             platform: "watchos",
-            cpuArch: "x86_64"
+            cpuArch: "x86_64",
+            devDir: "/Applications/Xcode.app/Contents/Developer",
+            xcodeVersion: "17B100"
         )
         #expect(
             actualFlags == [
@@ -166,6 +175,10 @@ struct PrepareHandlerTests {
                 "--watchos_minimum_os=\"15.0\"",
                 "--cpu=watchos_x86_64",
                 "--minimum_os_version=\"15.0\"",
+                "--xcode_version=\"17B100\"",
+                "--repo_env=DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\"",
+                "--repo_env=USE_CLANG_CL=\"17B100\"",
+                "--repo_env=XCODE_VERSION=\"17B100\"",
             ]
         )
     }
@@ -175,7 +188,9 @@ struct PrepareHandlerTests {
         let actualFlags = handler.buildArgs(
             minimumOsVersion: "15.0",
             platform: "darwin",
-            cpuArch: "arm64"
+            cpuArch: "arm64",
+            devDir: "/Applications/Xcode.app/Contents/Developer",
+            xcodeVersion: "17B100"
         )
         #expect(
             actualFlags == [
@@ -186,6 +201,10 @@ struct PrepareHandlerTests {
                 "--macos_minimum_os=\"15.0\"",
                 "--cpu=darwin_arm64",
                 "--minimum_os_version=\"15.0\"",
+                "--xcode_version=\"17B100\"",
+                "--repo_env=DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\"",
+                "--repo_env=USE_CLANG_CL=\"17B100\"",
+                "--repo_env=XCODE_VERSION=\"17B100\"",
             ]
         )
     }
@@ -195,7 +214,9 @@ struct PrepareHandlerTests {
         let actualFlags = handler.buildArgs(
             minimumOsVersion: "15.0",
             platform: "tvos",
-            cpuArch: "sim_arm64"
+            cpuArch: "sim_arm64",
+            devDir: "/Applications/Xcode.app/Contents/Developer",
+            xcodeVersion: "17B100"
         )
         #expect(
             actualFlags == [
@@ -206,6 +227,10 @@ struct PrepareHandlerTests {
                 "--tvos_minimum_os=\"15.0\"",
                 "--cpu=tvos_sim_arm64",
                 "--minimum_os_version=\"15.0\"",
+                "--xcode_version=\"17B100\"",
+                "--repo_env=DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\"",
+                "--repo_env=USE_CLANG_CL=\"17B100\"",
+                "--repo_env=XCODE_VERSION=\"17B100\"",
             ]
         )
     }
@@ -215,7 +240,9 @@ struct PrepareHandlerTests {
         let actualFlags = handler.buildArgs(
             minimumOsVersion: "15.0",
             platform: "visionos",
-            cpuArch: "sim_arm64"
+            cpuArch: "sim_arm64",
+            devDir: "/Applications/Xcode.app/Contents/Developer",
+            xcodeVersion: "17B100"
         )
         #expect(
             actualFlags == [
@@ -226,6 +253,10 @@ struct PrepareHandlerTests {
                 "--visionos_minimum_os=\"15.0\"",
                 "--cpu=visionos_sim_arm64",
                 "--minimum_os_version=\"15.0\"",
+                "--xcode_version=\"17B100\"",
+                "--repo_env=DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\"",
+                "--repo_env=USE_CLANG_CL=\"17B100\"",
+                "--repo_env=XCODE_VERSION=\"17B100\"",
             ]
         )
     }

--- a/Tests/SourceKitBazelBSPTests/TargetSourcesHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/TargetSourcesHandlerTests.swift
@@ -42,6 +42,7 @@ struct TargetSourcesHandlerTests {
             outputBase: "/tmp/output_base",
             outputPath: "/tmp/output_path",
             devDir: "/Applications/Xcode.app/Contents/Developer",
+            xcodeVersion: "17B100",
             devToolchainPath: "/a/b/XcodeDefault.xctoolchain/",
             executionRoot: "/tmp/output_path/execroot/_main",
             sdkRootPaths: ["iphonesimulator": "bar"]


### PR DESCRIPTION
When not using --compile-top-level, we need to additionally pass certain Xcode envs like rules_xcodeproj. Otherwise, while the build will work, the index will become corrupted after switching Xcode versions.