### PR TITLE
Fix more sources of non-determinism

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetDiscoverer.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetDiscoverer.swift
@@ -65,6 +65,7 @@ public enum BazelTargetDiscoverer {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
             .map { $0.components(separatedBy: " (")[0] }
+            .sorted()
 
         if discoveredTargets.isEmpty {
             throw BazelTargetDiscovererError.noTargetsDiscovered

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -214,7 +214,8 @@ final class BazelTargetStoreImpl: BazelTargetStore {
         // Query all the targets we are interested in one invocation:
         //  - Top-level targets (e.g. `ios_application`, `ios_unit_test`, etc.)
         //  - Dependencies of the top-level targets (e.g. `swift_library`, `objc_library`, etc.)
-        let allTargets =
+        //  - Source files connected to these targets
+        let (allTargets, allSrcs) =
             try bazelTargetQuerier
             .queryTargets(
                 config: initializedConfig,
@@ -254,6 +255,7 @@ final class BazelTargetStoreImpl: BazelTargetStore {
 
         let targetData = try BazelQueryParser.parseTargetsWithProto(
             from: dependencyTargets,
+            allSrcs: allSrcs,
             rootUri: initializedConfig.rootUri,
             toolchainPath: initializedConfig.devToolchainPath,
         )

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/AqueryResult.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/AqueryResult.swift
@@ -51,6 +51,11 @@ struct AqueryResult: Hashable {
         let configurations: [UInt32: Analysis_Configuration] = results.configuration.reduce(into: [:]) {
             result,
             configuration in
+            if result.keys.contains(configuration.id) {
+                logger.error(
+                    "Duplicate configuration found when aquerying (\(configuration.id))! This is unexpected. Will ignore the duplicate."
+                )
+            }
             result[configuration.id] = configuration
         }
         self.targets = targets

--- a/Tests/SourceKitBazelBSPTests/BazelTargetDiscovererTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetDiscovererTests.swift
@@ -38,7 +38,7 @@ struct BazelTargetDiscovererTests {
             commandRunner: commandRunner,
         )
 
-        #expect(targets == ["//Example/HelloWorld:HelloWorld", "//Example/AnotherApp:AnotherApp"])
+        #expect(targets == ["//Example/AnotherApp:AnotherApp", "//Example/HelloWorld:HelloWorld"])
         #expect(commandRunner.commands.count == 1)
         #expect(commandRunner.commands[0].command == "fakeBazel cquery 'kind(\"ios_application\", ...)' --output label")
     }
@@ -81,7 +81,7 @@ struct BazelTargetDiscovererTests {
             commandRunner: commandRunner,
         )
 
-        #expect(targets == ["//Example/HelloWorld:HelloWorld", "//Example/AnotherApp:AnotherApp"])
+        #expect(targets == ["//Example/AnotherApp:AnotherApp", "//Example/HelloWorld:HelloWorld"])
         #expect(commandRunner.commands.count == 1)
         #expect(
             commandRunner.commands[0].command
@@ -105,7 +105,7 @@ struct BazelTargetDiscovererTests {
             commandRunner: commandRunner,
         )
 
-        #expect(targets == ["//Example/HelloWorld:HelloWorld", "//Example/AnotherApp:AnotherApp"])
+        #expect(targets == ["//Example/AnotherApp:AnotherApp", "//Example/HelloWorld:HelloWorld"])
         #expect(commandRunner.commands.count == 1)
         #expect(
             commandRunner.commands[0].command

--- a/Tests/SourceKitBazelBSPTests/BazelTargetParserTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetParserTests.swift
@@ -63,7 +63,8 @@ struct BazelTargetParserTests {
         )
 
         let result = try BazelQueryParser.parseTargetsWithProto(
-            from: targets,
+            from: targets.rules,
+            allSrcs: targets.srcs,
             rootUri: rootUri,
             toolchainPath: toolchainPath,
         )

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -66,7 +66,8 @@ struct BazelTargetQuerierTests {
         #expect(ranCommands.count == 1)
         #expect(ranCommands[0].command == expectedCommand)
         #expect(ranCommands[0].cwd == mockRootUri)
-        #expect(!result.isEmpty)
+        #expect(result.rules.count > 0)
+        #expect(result.srcs.count > 0)
     }
 
     @Test
@@ -110,7 +111,8 @@ struct BazelTargetQuerierTests {
         #expect(ranCommands.count == 1)
         #expect(ranCommands[0].command == expectedCommand)
         #expect(ranCommands[0].cwd == mockRootUri)
-        #expect(!result.isEmpty)
+        #expect(result.rules.count > 0)
+        #expect(result.srcs.count > 0)
     }
 
     @Test
@@ -217,9 +219,7 @@ struct BazelTargetQuerierTests {
             dependencyKinds: dependencyKinds
         )
 
-        let rules = result.filter { target in
-            target.type == .rule
-        }
+        let rules = result.rules
 
         let ranCommands = runner.commands
 


### PR DESCRIPTION
I noticed sourcekit-lsp re-indexing files for what seemed to be non-determinism within the index unit files. I realized that the setup flow did not necessarily guarantee that things would be on a predictable order, and although I'm not sure how exactly this would result in the issue I saw, it seems that sorting arrays when possible during setup did in fact solve the issue for the Example project at least.