### PR TITLE
Fix PID workaround in the Example launch scripts

### DIFF
--- a/Example/.vscode/launch.json
+++ b/Example/.vscode/launch.json
@@ -16,7 +16,4 @@
       "timeout": 9999
     }
   ],
-  "options": {
-    "console": "integratedTerminal",
-  }
 }

--- a/Example/.vscode/tasks.json
+++ b/Example/.vscode/tasks.json
@@ -80,7 +80,7 @@
           "background": {
             "activeOnStart": true,
             "beginsPattern": "^Starting launch task\\.\\.\\.$",
-            "endsPattern": "^.*Launched with PID: .*"
+            "endsPattern": "^com.example.HelloWorld: .*"
           }
         },
         {

--- a/Example/scripts/lldb_kill_app.py
+++ b/Example/scripts/lldb_kill_app.py
@@ -9,4 +9,7 @@ from lldb_common import load_launch_info
 
 launch_info = load_launch_info()
 debug_pid = int(launch_info["pid"])
-os.kill(debug_pid, signal.SIGKILL)
+try:
+    os.kill(debug_pid, signal.SIGKILL)
+except Exception:
+    pass


### PR DESCRIPTION
While I would still like to have the app's output on the dedicated debug console, passing --console-pty allows overcoming an issue we had of tracking the state of the app in the terminal used to launch the app.