### PR TITLE
Improve handling of label conversions

### DIFF
--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -41,29 +41,10 @@ package struct BaseServerConfig: Equatable {
         topLevelRulesToDiscover: [TopLevelRuleType] = TopLevelRuleType.allCases,
     ) {
         self.bazelWrapper = bazelWrapper
+        self.targets = targets
         self.indexFlags = indexFlags
         self.filesToWatch = filesToWatch
         self.compileTopLevel = compileTopLevel
         self.topLevelRulesToDiscover = topLevelRulesToDiscover
-
-        // We need to post-process the target list provided by the user
-        // because the queries will always return the "full" label.
-        // e.g: "//foo/bar" -> "//foo/bar:bar"
-        // We need to also de-dupe them if the user passed wildcards in Serve.swift.
-        self.targets = Set(targets.map { $0.toFullLabel() }).sorted()
-    }
-}
-
-extension String {
-    func toFullLabel() -> String {
-        let paths = components(separatedBy: "/")
-        let lastComponent = paths.last
-        if lastComponent?.contains(":") == true {
-            return self
-        } else if let lastComponent = lastComponent {
-            return "\(self):\(lastComponent)"
-        } else {
-            return self
-        }
     }
 }

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -89,7 +89,7 @@ struct BazelTargetQuerierTests {
         let config = Self.makeInitializedConfig()
 
         let expectedCommand =
-            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld:HelloWorld)) in   $topLevelTargets   union   kind(\"source file|swift_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
+            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"source file|swift_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
         runnerMock.setResponse(for: expectedCommand, cwd: Self.mockRootUri, response: exampleCqueryOutput)
 
         _ = try querier.cqueryTargets(
@@ -112,7 +112,7 @@ struct BazelTargetQuerierTests {
         let config = Self.makeInitializedConfig(targets: ["//HelloWorld", "//Tests"])
 
         let expectedCommand =
-            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld:HelloWorld //Tests:Tests)) in   $topLevelTargets   union   kind(\"objc_library|swift_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
+            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld //Tests)) in   $topLevelTargets   union   kind(\"objc_library|swift_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
         runnerMock.setResponse(for: expectedCommand, cwd: Self.mockRootUri, response: exampleCqueryOutput)
 
         _ = try querier.cqueryTargets(
@@ -136,13 +136,13 @@ struct BazelTargetQuerierTests {
 
         runnerMock.setResponse(
             for:
-                "bazel --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld:HelloWorld)) in   $topLevelTargets   union   kind(\"swift_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto",
+                "bazel --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"swift_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto",
             cwd: Self.mockRootUri,
             response: exampleCqueryOutput
         )
         runnerMock.setResponse(
             for:
-                "bazel --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld:HelloWorld)) in   $topLevelTargets   union   kind(\"objc_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto",
+                "bazel --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"objc_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto",
             cwd: Self.mockRootUri,
             response: exampleCqueryOutput
         )
@@ -178,7 +178,7 @@ struct BazelTargetQuerierTests {
         let config = Self.makeInitializedConfig()
 
         let expectedCommand =
-            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld:HelloWorld)) in   $topLevelTargets   union   kind(\"source file|swift_library|alias|_watchos_internal_unit_test_bundle\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
+            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"source file|swift_library|alias|_watchos_internal_unit_test_bundle\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
         runnerMock.setResponse(for: expectedCommand, cwd: Self.mockRootUri, response: exampleCqueryOutput)
 
         _ = try querier.cqueryTargets(


### PR DESCRIPTION
Recent refactors made this case easier to handle. We don't need to hack it on the BaseServerConfig anymore.