### PR TITLE
Add support for C/C++, improve Obj-C handling

### DIFF
--- a/Example/HelloWorld/BUILD
+++ b/Example/HelloWorld/BUILD
@@ -33,12 +33,29 @@ objc_library(
     name = "TodoObjCSupport",
     srcs = glob(
         [
-            "TodoObjCSupport/Sources/*.h",
+            "TodoObjCSupport/Sources/*.mm",
             "TodoObjCSupport/Sources/*.m",
         ],
     ),
     hdrs = glob(["TodoObjCSupport/Sources/*.h"]),
     aspect_hints = [":TodoObjCSupport_hint"],
+    deps = [":TodoCSupport"],
+)
+
+cc_library(
+    name = "TodoCSupport",
+    srcs = glob(
+        [
+            "TodoCSupport/src/*.cpp",
+            "TodoCSupport/src/*.c",
+        ],
+    ),
+    hdrs = glob(
+        [
+            "TodoCSupport/include/*.hpp",
+            "TodoCSupport/include/*.h",
+        ],
+    ),
 )
 
 swift_library(

--- a/Example/HelloWorld/BUILD
+++ b/Example/HelloWorld/BUILD
@@ -3,6 +3,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_tes
 load("@build_bazel_rules_apple//apple:macos.bzl", "macos_application", "macos_command_line_application", "macos_unit_test")
 load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_application", "watchos_extension", "watchos_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_interop_hint", "swift_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@sourcekit_bazel_bsp//rules:setup_sourcekit_bsp.bzl", "setup_sourcekit_bsp")
 load("//tools:apple.bzl", "IOS_MINIMUM_OS_VERSION", "WATCHOS_MINIMUM_OS_VERSION", "MACOS_MINIMUM_OS_VERSION")
 

--- a/Example/HelloWorld/HelloWorldLib/Sources/TodoItemRow.swift
+++ b/Example/HelloWorld/HelloWorldLib/Sources/TodoItemRow.swift
@@ -42,9 +42,13 @@ struct TodoItemRow: View {
                     .foregroundColor(item.isCompleted ? .gray : .primary)
                     .animation(.easeInOut(duration: 0.2), value: item.isCompleted)
 
-                Text(SKDateDistanceCalculator.humanReadableDistance(fromNow: item.createdAt))
+                Text(SKObjCppUtils.humanReadableDistance(fromNow: item.createdAt))
                     .font(.caption)
                     .foregroundColor(.gray)
+                    .onAppear {
+                        print(SKObjCUtils.greetingFromC() as Any)
+                        print(SKObjCUtils.multiply(withC: 2, b: 2))
+                    }
             }
 
             Spacer()

--- a/Example/HelloWorld/TodoCSupport/include/SKCUtils.h
+++ b/Example/HelloWorld/TodoCSupport/include/SKCUtils.h
@@ -17,5 +17,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#import "SKObjCppUtils.h"
-#import "SKObjCUtils.h"
+#ifndef SK_C_UTILS_H
+#define SK_C_UTILS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char* sk_c_get_greeting(void);
+int sk_c_multiply(int a, int b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Example/HelloWorld/TodoCSupport/include/SKCppUtils.hpp
+++ b/Example/HelloWorld/TodoCSupport/include/SKCppUtils.hpp
@@ -1,0 +1,13 @@
+#ifndef SK_CPP_UTILS_HPP
+#define SK_CPP_UTILS_HPP
+
+#include <string>
+
+namespace SKCppUtils {
+
+std::string getGreeting();
+int add(int a, int b);
+
+} // namespace SKCppUtils
+
+#endif

--- a/Example/HelloWorld/TodoCSupport/src/SKCUtils.c
+++ b/Example/HelloWorld/TodoCSupport/src/SKCUtils.c
@@ -17,5 +17,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#import "SKObjCppUtils.h"
-#import "SKObjCUtils.h"
+#include "../include/SKCUtils.h"
+
+const char* sk_c_get_greeting(void) {
+    return "Hello from C!";
+}
+
+int sk_c_multiply(int a, int b) {
+    return a * b;
+}

--- a/Example/HelloWorld/TodoCSupport/src/SKCppUtils.cpp
+++ b/Example/HelloWorld/TodoCSupport/src/SKCppUtils.cpp
@@ -1,0 +1,13 @@
+#include "../include/SKCppUtils.hpp"
+
+namespace SKCppUtils {
+
+std::string getGreeting() {
+    return "Hello from C++!";
+}
+
+int add(int a, int b) {
+    return a + b;
+}
+
+} // namespace SKCppUtils

--- a/Example/HelloWorld/TodoObjCSupport/Sources/SKObjCUtils.h
+++ b/Example/HelloWorld/TodoObjCSupport/Sources/SKObjCUtils.h
@@ -17,5 +17,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#import "SKObjCppUtils.h"
-#import "SKObjCUtils.h"
+#import <Foundation/Foundation.h>
+
+@interface SKObjCUtils : NSObject
+
++ (NSString *)greetingFromC;
++ (NSInteger)multiplyWithC:(NSInteger)a b:(NSInteger)b;
+
+@end

--- a/Example/HelloWorld/TodoObjCSupport/Sources/SKObjCUtils.m
+++ b/Example/HelloWorld/TodoObjCSupport/Sources/SKObjCUtils.m
@@ -17,5 +17,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#import "SKObjCppUtils.h"
-#import "SKObjCUtils.h"
+#import "HelloWorld/TodoObjCSupport/Sources/SKObjCUtils.h"
+#import "HelloWorld/TodoCSupport/include/SKCUtils.h"
+
+@implementation SKObjCUtils
+
++ (NSString *)greetingFromC {
+    const char *cGreeting = sk_c_get_greeting();
+    return [NSString stringWithUTF8String:cGreeting];
+}
+
++ (NSInteger)multiplyWithC:(NSInteger)a b:(NSInteger)b {
+    return sk_c_multiply((int)a, (int)b);
+}
+
+@end

--- a/Example/HelloWorld/TodoObjCSupport/Sources/SKObjCppUtils.h
+++ b/Example/HelloWorld/TodoObjCSupport/Sources/SKObjCppUtils.h
@@ -19,7 +19,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface SKDateDistanceCalculator : NSObject
+@interface SKObjCppUtils : NSObject
 
 /**
  * Calculates the time interval between the given date and now

--- a/Example/HelloWorld/TodoObjCSupport/Sources/SKObjCppUtils.mm
+++ b/Example/HelloWorld/TodoObjCSupport/Sources/SKObjCppUtils.mm
@@ -17,14 +17,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#import "HelloWorld/TodoObjCSupport/Sources/SKDateDistanceCalculator.h"
+#import "HelloWorld/TodoObjCSupport/Sources/SKObjCppUtils.h"
+#import "HelloWorld/TodoCSupport/include/SKCppUtils.hpp"
 
-@implementation SKDateDistanceCalculator
+@implementation SKObjCppUtils
 
 + (NSTimeInterval)distanceFromNow:(NSDate *)date {
   if (!date) {
     return 0.0;
   }
+
+  NSLog(@"%s", SKCppUtils::getGreeting().c_str());
+  NSLog(@"%ld", (long)SKCppUtils::add(1, 2));
 
   NSDate *now = [NSDate date];
   return [now timeIntervalSinceDate:date];

--- a/Example/MODULE.bazel
+++ b/Example/MODULE.bazel
@@ -17,5 +17,5 @@ bazel_dep(
 )
 
 bazel_dep(name = "apple_support", version = "1.24.5", repo_name = "build_bazel_apple_support")
-
+bazel_dep(name = "rules_cc", version = "0.2.16")
 bazel_dep(name = "aspect_bazel_lib", version = "2.13.0")

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -69,10 +69,10 @@ final class BazelTargetQuerier {
     /// listing all of their dependencies and source files.
     func cqueryTargets(
         config: InitializedServerConfig,
-        supportedRuleKinds: [SupportedRuleKind],
+        supportedDependencyRuleTypes: [DependencyRuleType],
         supportedTopLevelRuleTypes: [TopLevelRuleType],
     ) throws -> ProcessedCqueryResult {
-        if supportedRuleKinds.isEmpty {
+        if supportedDependencyRuleTypes.isEmpty {
             throw BazelTargetQuerierError.noKinds
         }
         if supportedTopLevelRuleTypes.isEmpty {
@@ -84,7 +84,7 @@ final class BazelTargetQuerier {
             throw BazelTargetQuerierError.noTargets
         }
 
-        var kindsToFilterFor = Set(supportedRuleKinds.map { $0.rawValue }).sorted()
+        var kindsToFilterFor = Set(supportedDependencyRuleTypes.map { $0.rawValue }).sorted()
 
         // We need to also use the `alias` mnemonic for this query to work properly.
         // This is because --output proto doesn't follow the aliases automatically,
@@ -135,7 +135,7 @@ final class BazelTargetQuerier {
             from: output,
             testBundleRules: testBundleRules,
             userProvidedTargets: userProvidedTargets,
-            supportedRuleKinds: supportedRuleKinds,
+            supportedDependencyRuleTypes: supportedDependencyRuleTypes,
             supportedTopLevelRuleTypes: supportedTopLevelRuleTypes,
             rootUri: config.rootUri,
             executionRoot: config.executionRoot,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -91,6 +91,10 @@ final class BazelTargetQuerier {
         // so we need this info to do it ourselves.
         kindsToFilterFor.append("alias")
 
+        // Always fetch source information.
+        // FIXME: Need to also handle `generated file`
+        kindsToFilterFor.append("source file")
+
         // If we're searching for test rules, we need to also include their test bundle rules.
         // Otherwise we won't be able to map test dependencies back to their top level parents.
         let testBundleRules = supportedTopLevelRuleTypes.compactMap { $0.testBundleRule }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -69,10 +69,10 @@ final class BazelTargetQuerier {
     /// listing all of their dependencies and source files.
     func cqueryTargets(
         config: InitializedServerConfig,
-        dependencyKinds: [String],
+        supportedRuleKinds: [SupportedRuleKind],
         supportedTopLevelRuleTypes: [TopLevelRuleType],
     ) throws -> ProcessedCqueryResult {
-        if dependencyKinds.isEmpty {
+        if supportedRuleKinds.isEmpty {
             throw BazelTargetQuerierError.noKinds
         }
         if supportedTopLevelRuleTypes.isEmpty {
@@ -84,7 +84,7 @@ final class BazelTargetQuerier {
             throw BazelTargetQuerierError.noTargets
         }
 
-        var kindsToFilterFor = dependencyKinds
+        var kindsToFilterFor = Set(supportedRuleKinds.map { $0.rawValue }).sorted()
 
         // We need to also use the `alias` mnemonic for this query to work properly.
         // This is because --output proto doesn't follow the aliases automatically,
@@ -135,6 +135,7 @@ final class BazelTargetQuerier {
             from: output,
             testBundleRules: testBundleRules,
             userProvidedTargets: userProvidedTargets,
+            supportedRuleKinds: supportedRuleKinds,
             supportedTopLevelRuleTypes: supportedTopLevelRuleTypes,
             rootUri: config.rootUri,
             executionRoot: config.executionRoot,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -78,7 +78,7 @@ protocol BazelTargetQuerierParser: AnyObject {
         from data: Data,
         testBundleRules: [String],
         userProvidedTargets: [String],
-        supportedRuleKinds: [SupportedRuleKind],
+        supportedDependencyRuleTypes: [DependencyRuleType],
         supportedTopLevelRuleTypes: [TopLevelRuleType],
         rootUri: String,
         executionRoot: String,
@@ -98,7 +98,7 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
         from data: Data,
         testBundleRules: [String],
         userProvidedTargets: [String],
-        supportedRuleKinds: [SupportedRuleKind],
+        supportedDependencyRuleTypes: [DependencyRuleType],
         supportedTopLevelRuleTypes: [TopLevelRuleType],
         rootUri: String,
         executionRoot: String,
@@ -113,7 +113,7 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
                 return !$0.rule.name.hasPrefix("@")
             }
 
-        let supportedRuleKindsSet = Set(supportedRuleKinds)
+        let supportedDependencyRuleTypesSet = Set(supportedDependencyRuleTypes)
         let testBundleRulesSet = Set(testBundleRules)
         var seenLabels = Set<String>()
         var seenSourceFiles = Set<String>()
@@ -276,7 +276,7 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
                 canDebug: false
             )
 
-            guard let ruleKind = SupportedRuleKind(rawValue: rule.ruleClass), supportedRuleKindsSet.contains(ruleKind) else {
+            guard let ruleType = DependencyRuleType(rawValue: rule.ruleClass), supportedDependencyRuleTypesSet.contains(ruleType) else {
                 // The cquery seems to pick up things that have the expected name somewhere within the string, like
                 // my_custom_swift_library. Ignore those
                 logger.warning("Skipping target \(rule.name, privacy: .public) with unexpected rule class: \(rule.ruleClass)")
@@ -289,7 +289,7 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
                 baseDirectory: baseDirectory,
                 tags: [.library],
                 capabilities: capabilities,
-                languageIds: [ruleKind.language],
+                languageIds: [ruleType.language],
                 dependencies: deps,
                 dataKind: .sourceKit,
                 data: try SourceKitBuildTarget(

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -276,10 +276,14 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
                 canDebug: false
             )
 
-            guard let ruleType = DependencyRuleType(rawValue: rule.ruleClass), supportedDependencyRuleTypesSet.contains(ruleType) else {
+            guard let ruleType = DependencyRuleType(rawValue: rule.ruleClass),
+                supportedDependencyRuleTypesSet.contains(ruleType)
+            else {
                 // The cquery seems to pick up things that have the expected name somewhere within the string, like
                 // my_custom_swift_library. Ignore those
-                logger.warning("Skipping target \(rule.name, privacy: .public) with unexpected rule class: \(rule.ruleClass)")
+                logger.warning(
+                    "Skipping target \(rule.name, privacy: .public) with unexpected rule class: \(rule.ruleClass). This can also happen if you used --dependency-rule-to-discover flag is set to filter this type."
+                )
                 continue
             }
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -89,8 +89,11 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
         self.initializedConfig = initializedConfig
         self.bazelTargetQuerier = bazelTargetQuerier
         self.supportedDependencyRuleTypes = initializedConfig.baseConfig.dependencyRulesToDiscover
-        self.compileMnemonicsToFilter = Set(initializedConfig.baseConfig.dependencyRulesToDiscover.map { $0.compileMnemonic }).sorted()
-        self.topLevelMnemonicsToFilter = Set(initializedConfig.baseConfig.topLevelRulesToDiscover.map { $0.mmnemonic }).sorted()
+        self.compileMnemonicsToFilter = Set(
+            initializedConfig.baseConfig.dependencyRulesToDiscover.map { $0.compileMnemonic }
+        ).sorted()
+        self.topLevelMnemonicsToFilter = Set(initializedConfig.baseConfig.topLevelRulesToDiscover.map { $0.mmnemonic })
+            .sorted()
     }
 
     /// Returns true if the store has actually processed something.

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -74,7 +74,7 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
     private let initializedConfig: InitializedServerConfig
     private let bazelTargetQuerier: BazelTargetQuerier
 
-    private let supportedRuleKinds: [SupportedRuleKind]
+    private let supportedDependencyRuleTypes: [DependencyRuleType]
     private let compileMnemonicsToFilter: [String]
     private let topLevelMnemonicsToFilter: [String]
 
@@ -85,12 +85,11 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
     init(
         initializedConfig: InitializedServerConfig,
         bazelTargetQuerier: BazelTargetQuerier = BazelTargetQuerier(),
-        supportedRuleKinds: [SupportedRuleKind] = SupportedRuleKind.allCases,
     ) {
         self.initializedConfig = initializedConfig
         self.bazelTargetQuerier = bazelTargetQuerier
-        self.supportedRuleKinds = supportedRuleKinds
-        self.compileMnemonicsToFilter = Set(supportedRuleKinds.map { $0.compileMnemonic }).sorted()
+        self.supportedDependencyRuleTypes = initializedConfig.baseConfig.dependencyRulesToDiscover
+        self.compileMnemonicsToFilter = Set(initializedConfig.baseConfig.dependencyRulesToDiscover.map { $0.compileMnemonic }).sorted()
         self.topLevelMnemonicsToFilter = Set(initializedConfig.baseConfig.topLevelRulesToDiscover.map { $0.mmnemonic }).sorted()
     }
 
@@ -194,7 +193,7 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
         // And process the relation between these different targets and sources.
         let cqueryResult = try bazelTargetQuerier.cqueryTargets(
             config: initializedConfig,
-            supportedRuleKinds: supportedRuleKinds,
+            supportedDependencyRuleTypes: initializedConfig.baseConfig.dependencyRulesToDiscover,
             supportedTopLevelRuleTypes: initializedConfig.baseConfig.topLevelRulesToDiscover
         )
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -67,14 +67,6 @@ enum BazelTargetStoreError: Error, LocalizedError {
 /// Used by many of the requests to calculate and provide data about the project's targets.
 final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
 
-    // The list of kinds that provide compilation params that are used by the BSP.
-    // These are collected from the top-level targets that depend on them.
-    static let libraryKinds: [String] = ["swift_library", "objc_library"]
-    static let sourceFileKinds: [String] = ["source file"]
-
-    // The mnemonics representing compilation actions
-    static let compileMnemonics: [String] = ["SwiftCompile", "ObjcCompile", "CppCompile"]
-
     // The mnemonics representing top-level rule actions
     // - `BundleTreeApp` for finding bundling rules like `ios_unit_test`, `ios_application`
     // - `SignBinary` for finding macOS CLI app rules like `macos_command_line_application`
@@ -199,9 +191,10 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
         //  - Dependencies of the top-level targets (e.g. `swift_library`, `objc_library`, etc.)
         //  - Source files connected to these targets
         // And process the relation between these different targets and sources.
+        let dependencyKindsToFilter = SupportedLanguages.ruleKinds.keys.sorted()
         let cqueryResult = try bazelTargetQuerier.cqueryTargets(
             config: initializedConfig,
-            dependencyKinds: Self.libraryKinds + Self.sourceFileKinds,
+            dependencyKinds: dependencyKindsToFilter,
             supportedTopLevelRuleTypes: initializedConfig.baseConfig.topLevelRulesToDiscover
         )
 
@@ -213,7 +206,7 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
         let aqueryResult = try bazelTargetQuerier.aquery(
             topLevelTargets: cqueryResult.topLevelTargets,
             config: initializedConfig,
-            mnemonics: Self.compileMnemonics + Self.topLevelMnemonics
+            mnemonics: SupportedLanguages.compileMnemonics + Self.topLevelMnemonics
         )
 
         self.aqueryResult = aqueryResult

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/DependencyRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/DependencyRuleType.swift
@@ -17,15 +17,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ArgumentParser
 import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
 
 private let logger = makeFileLevelBSPLogger()
 
-// Contains data about all the rule kinds the BSP knows how to parse.
-// See also: SupportedExtension.swift
-enum SupportedRuleKind: String, CaseIterable {
+/// The list of **dependency rules** we know how to process in the BSP.
+/// See also: SupportedExtension.swift, TopLevelRuleType.swift
+public enum DependencyRuleType: String, CaseIterable, ExpressibleByArgument, Sendable {
     case swiftLibrary = "swift_library"
     case objcLibrary = "objc_library"
     case ccLibrary = "cc_library"

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedExtension.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedExtension.swift
@@ -48,11 +48,11 @@ enum SupportedExtension: String, CaseIterable {
     // Source: https://github.com/swiftlang/sourcekit-lsp/blob/7495f5532fdb17184d69518f46a207e596b26c64/Sources/LanguageServerProtocolExtensions/Language%2BInference.swift#L33
     var language: Language {
         switch self {
-            case .c: return .c
-            case .cpp, .cc, .cxx, .hpp: return .cpp
-            case .m: return .objective_c
-            case .mm, .h: return .objective_cpp
-            case .swift: return .swift
+        case .c: return .c
+        case .cpp, .cc, .cxx, .hpp: return .cpp
+        case .m: return .objective_c
+        case .mm, .h: return .objective_cpp
+        case .swift: return .swift
         }
     }
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedExtension.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedExtension.swift
@@ -24,7 +24,7 @@ import LanguageServerProtocol
 private let logger = makeFileLevelBSPLogger()
 
 // Contains data about all the file types the BSP knows how to parse.
-// See also: SupportedRuleKind.swift
+// See also: DependencyRuleType.swift, TopLevelRuleType.swift
 enum SupportedExtension: String, CaseIterable {
     case c
     case cc

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedExtension.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedExtension.swift
@@ -26,11 +26,16 @@ private let logger = makeFileLevelBSPLogger()
 // Contains data about all the file types the BSP knows how to parse.
 // See also: DependencyRuleType.swift, TopLevelRuleType.swift
 enum SupportedExtension: String, CaseIterable {
+    case cCaps = "C"
     case c
     case cc
     case cpp
     case cxx
+    case inc
+    case ipp
+    case hCaps = "H"
     case h
+    case hh
     case hpp
     case m
     case mm
@@ -38,18 +43,19 @@ enum SupportedExtension: String, CaseIterable {
 
     var kind: SourceKitSourceItemKind {
         switch self {
-        case .h, .hpp: return .header
-        case .c, .cc, .cpp, .cxx: return .source
+        case .hCaps, .h, .hh, .hpp, .inc, .ipp: return .header
+        case .cCaps, .c, .cc, .cpp, .cxx: return .source
         case .m, .mm: return .source
         case .swift: return .source
         }
     }
 
-    // Source: https://github.com/swiftlang/sourcekit-lsp/blob/7495f5532fdb17184d69518f46a207e596b26c64/Sources/LanguageServerProtocolExtensions/Language%2BInference.swift#L33
+    // Source for .h == Obj-C++: https://github.com/swiftlang/sourcekit-lsp/blob/7495f5532fdb17184d69518f46a207e596b26c64/Sources/LanguageServerProtocolExtensions/Language%2BInference.swift#L33
+    // Technically not 100% correct, but does the job for what it needs to do.
     var language: Language {
         switch self {
         case .c: return .c
-        case .cpp, .cc, .cxx, .hpp: return .cpp
+        case .cCaps, .cpp, .cc, .cxx, .hCaps, .hh, .hpp, .inc, .ipp: return .cpp
         case .m: return .objective_c
         case .mm, .h: return .objective_cpp
         case .swift: return .swift

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedExtension.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedExtension.swift
@@ -23,13 +23,36 @@ import LanguageServerProtocol
 
 private let logger = makeFileLevelBSPLogger()
 
-enum SupportedLanguages {
-    static let headerExtensions: Set<String> = ["h", "hpp"]
-    static let sourceExtensions: Set<String> = ["c", "cpp", "cc", "cxx", "m", "mm", "swift"]
-    static let compileMnemonics: [String] = ["SwiftCompile", "ObjcCompile"] // CppCompile
-    static let ruleKinds: [String: Language] = [
-        "swift_library": .swift,
-        "objc_library": .objective_c
-        // "cc_library": .cpp,
-    ]
+// Contains data about all the file types the BSP knows how to parse.
+// See also: SupportedRuleKind.swift
+enum SupportedExtension: String, CaseIterable {
+    case c
+    case cc
+    case cpp
+    case cxx
+    case h
+    case hpp
+    case m
+    case mm
+    case swift
+
+    var kind: SourceKitSourceItemKind {
+        switch self {
+        case .h, .hpp: return .header
+        case .c, .cc, .cpp, .cxx: return .source
+        case .m, .mm: return .source
+        case .swift: return .source
+        }
+    }
+
+    // Source: https://github.com/swiftlang/sourcekit-lsp/blob/7495f5532fdb17184d69518f46a207e596b26c64/Sources/LanguageServerProtocolExtensions/Language%2BInference.swift#L33
+    var language: Language {
+        switch self {
+            case .c: return .c
+            case .cpp, .cc, .cxx, .hpp: return .cpp
+            case .m: return .objective_c
+            case .mm, .h: return .objective_cpp
+            case .swift: return .swift
+        }
+    }
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedLanguages.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedLanguages.swift
@@ -17,5 +17,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#import "SKObjCppUtils.h"
-#import "SKObjCUtils.h"
+import BuildServerProtocol
+import Foundation
+import LanguageServerProtocol
+
+private let logger = makeFileLevelBSPLogger()
+
+enum SupportedLanguages {
+    static let headerExtensions: Set<String> = ["h", "hpp"]
+    static let sourceExtensions: Set<String> = ["c", "cpp", "cc", "cxx", "m", "mm", "swift"]
+    static let compileMnemonics: [String] = ["SwiftCompile", "ObjcCompile"] // CppCompile
+    static let ruleKinds: [String: Language] = [
+        "swift_library": .swift,
+        "objc_library": .objective_c
+        // "cc_library": .cpp,
+    ]
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedRuleKind.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/SupportedRuleKind.swift
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import BuildServerProtocol
+import Foundation
+import LanguageServerProtocol
+
+private let logger = makeFileLevelBSPLogger()
+
+// Contains data about all the rule kinds the BSP knows how to parse.
+// See also: SupportedExtension.swift
+enum SupportedRuleKind: String, CaseIterable {
+    case swiftLibrary = "swift_library"
+    case objcLibrary = "objc_library"
+    case ccLibrary = "cc_library"
+
+    var compileMnemonic: String {
+        switch self {
+        case .swiftLibrary: return "SwiftCompile"
+        case .objcLibrary: return "ObjcCompile"
+        case .ccLibrary: return "CppCompile"
+        }
+    }
+
+    var language: Language {
+        switch self {
+        case .swiftLibrary: return .swift
+        case .objcLibrary: return .objective_c
+        case .ccLibrary: return .cpp
+        }
+    }
+}

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
@@ -19,7 +19,7 @@
 
 import ArgumentParser
 
-// The list of **top-level rules** we know how to process in the BSP.
+/// The list of **top-level rules** we know how to process in the BSP.
 public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument, Sendable {
     case iosApplication = "ios_application"
     case iosAppClip = "ios_app_clip"
@@ -53,9 +53,43 @@ public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument, Senda
         return ".__internal__.__test_bundle"
     }
 
-    // Some test rule types inject a bundle target between the rule and its dependencies.
-    // We need to keep track of them to be able to parse those rules properly.
-    // If the rule does not generate a bundle target, returns nil.
+    /// The mnemonic that assembles everything together in this rule.
+    /// This is used to find the correct variant of each library we need to parse.
+    var mmnemonic: String {
+        switch self {
+        case .iosApplication: return "BundleTreeApp"
+        case .iosAppClip: return "BundleTreeApp"
+        case .iosExtension: return "BundleTreeApp"
+        case .iosUnitTest: return "BundleTreeApp"
+        case .iosUiTest: return "BundleTreeApp"
+        case .iosBuildTest: return "TestRunner"
+        case .watchosApplication: return "BundleTreeApp"
+        case .watchosExtension: return "BundleTreeApp"
+        case .watchosUnitTest: return "BundleTreeApp"
+        case .watchosUiTest: return "BundleTreeApp"
+        case .watchosBuildTest: return "TestRunner"
+        case .macosApplication: return "BundleTreeApp"
+        case .macosExtension: return "BundleTreeApp"
+        case .macosCommandLineApplication: return "SignBinary"
+        case .macosUnitTest: return "BundleTreeApp"
+        case .macosUiTest: return "BundleTreeApp"
+        case .macosBuildTest: return "TestRunner"
+        case .tvosApplication: return "BundleTreeApp"
+        case .tvosExtension: return "BundleTreeApp"
+        case .tvosUnitTest: return "BundleTreeApp"
+        case .tvosUiTest: return "BundleTreeApp"
+        case .tvosBuildTest: return "TestRunner"
+        case .visionosApplication: return "BundleTreeApp"
+        case .visionosExtension: return "BundleTreeApp"
+        case .visionosUnitTest: return "BundleTreeApp"
+        case .visionosUiTest: return "BundleTreeApp"
+        case .visionosBuildTest: return "TestRunner"
+        }
+    }
+
+    /// Some test rule types inject a bundle target between the rule and its dependencies.
+    /// We need to keep track of them to be able to parse those rules properly.
+    /// If the rule does not generate a bundle target, returns nil.
     var testBundleRule: String? {
         switch self {
         case .iosUnitTest: return "_ios_internal_unit_test_bundle"

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
@@ -58,33 +58,13 @@ public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument, Senda
     /// This is used to find the correct variant of each library we need to parse.
     var mmnemonic: String {
         switch self {
-        case .iosApplication: return "BundleTreeApp"
-        case .iosAppClip: return "BundleTreeApp"
-        case .iosExtension: return "BundleTreeApp"
-        case .iosUnitTest: return "BundleTreeApp"
-        case .iosUiTest: return "BundleTreeApp"
-        case .iosBuildTest: return "TestRunner"
-        case .watchosApplication: return "BundleTreeApp"
-        case .watchosExtension: return "BundleTreeApp"
-        case .watchosUnitTest: return "BundleTreeApp"
-        case .watchosUiTest: return "BundleTreeApp"
-        case .watchosBuildTest: return "TestRunner"
-        case .macosApplication: return "BundleTreeApp"
-        case .macosExtension: return "BundleTreeApp"
+        case .iosApplication, .iosAppClip, .iosExtension, .iosUnitTest, .iosUiTest, .watchosApplication,
+            .watchosExtension, .watchosUnitTest, .watchosUiTest, .macosApplication, .macosExtension, .macosUnitTest,
+            .macosUiTest, .tvosApplication, .tvosExtension, .tvosUnitTest, .tvosUiTest, .visionosApplication,
+            .visionosExtension, .visionosUnitTest, .visionosUiTest:
+            return "BundleTreeApp"
+        case .iosBuildTest, .watchosBuildTest, .macosBuildTest, .tvosBuildTest, .visionosBuildTest: return "TestRunner"
         case .macosCommandLineApplication: return "SignBinary"
-        case .macosUnitTest: return "BundleTreeApp"
-        case .macosUiTest: return "BundleTreeApp"
-        case .macosBuildTest: return "TestRunner"
-        case .tvosApplication: return "BundleTreeApp"
-        case .tvosExtension: return "BundleTreeApp"
-        case .tvosUnitTest: return "BundleTreeApp"
-        case .tvosUiTest: return "BundleTreeApp"
-        case .tvosBuildTest: return "TestRunner"
-        case .visionosApplication: return "BundleTreeApp"
-        case .visionosExtension: return "BundleTreeApp"
-        case .visionosUnitTest: return "BundleTreeApp"
-        case .visionosUiTest: return "BundleTreeApp"
-        case .visionosBuildTest: return "TestRunner"
         }
     }
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
@@ -20,6 +20,7 @@
 import ArgumentParser
 
 /// The list of **top-level rules** we know how to process in the BSP.
+/// See also: SupportedExtension.swift, DependencyRuleType.swift
 public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument, Sendable {
     case iosApplication = "ios_application"
     case iosAppClip = "ios_app_clip"

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -86,7 +86,9 @@ final class BazelTargetCompilerArgsExtractor {
         case .swift:
             return .swiftModule
         case .c, .cpp, .objective_c, .objective_cpp:
-            if let pathExtension = uri.fileURL?.pathExtension, SupportedExtension(rawValue: pathExtension)?.kind == .header {
+            if let pathExtension = uri.fileURL?.pathExtension,
+                SupportedExtension(rawValue: pathExtension)?.kind == .header
+            {
                 return .cHeader
             }
             // Make the path relative, as this is what aquery will return

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -86,7 +86,7 @@ final class BazelTargetCompilerArgsExtractor {
         case .swift:
             return .swiftModule
         case .c, .cpp, .objective_c, .objective_cpp:
-            if let pathExtension = uri.fileURL?.pathExtension, SupportedLanguages.headerExtensions.contains(pathExtension) {
+            if let pathExtension = uri.fileURL?.pathExtension, SupportedExtension(rawValue: pathExtension)?.kind == .header {
                 return .cHeader
             }
             // Make the path relative, as this is what aquery will return
@@ -282,6 +282,12 @@ extension BazelTargetCompilerArgsExtractor {
 
             // Drop -c for clang. sourcekit-lsp will instead inject -fsyntax-only.
             if arg == "-c", case .cImpl = strategy {
+                index += 1
+                continue
+            }
+
+            // Skip warnings as errors since sourcekit-lsp adds some warnings of its own
+            if arg == "-Werror", case .cImpl = strategy {
                 index += 1
                 continue
             }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFiles/WatchedFileChangeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFiles/WatchedFileChangeHandler.swift
@@ -34,10 +34,20 @@ final class WatchedFileChangeHandler {
     private let supportedFileExtensions: Set<String> = [
         "swift",
         "h",
+        "hh",
+        "hpp",
+        "hxx",
+        "inc",
+        "inl",
+        "H",
         "m",
         "mm",
         "c",
+        "cc",
+        "cxx",
         "cpp",
+        "c++",
+        "C",
     ]
 
     init(

--- a/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFiles/WatchedFileChangeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFiles/WatchedFileChangeHandler.swift
@@ -31,24 +31,7 @@ final class WatchedFileChangeHandler {
     private var observers: [any InvalidatedTargetObserver]
     private weak var connection: LSPConnection?
 
-    private let supportedFileExtensions: Set<String> = [
-        "swift",
-        "h",
-        "hh",
-        "hpp",
-        "hxx",
-        "inc",
-        "inl",
-        "H",
-        "m",
-        "mm",
-        "c",
-        "cc",
-        "cxx",
-        "cpp",
-        "c++",
-        "C",
-    ]
+    private let supportedFileExtensions: Set<String> = Set(SupportedExtension.allCases.map { $0.rawValue })
 
     init(
         targetStore: BazelTargetStore,

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -31,6 +31,7 @@ package struct BaseServerConfig: Equatable {
     let filesToWatch: String?
     let compileTopLevel: Bool
     let topLevelRulesToDiscover: [TopLevelRuleType]
+    let dependencyRulesToDiscover: [DependencyRuleType]
 
     package init(
         bazelWrapper: String,
@@ -39,6 +40,7 @@ package struct BaseServerConfig: Equatable {
         filesToWatch: String?,
         compileTopLevel: Bool,
         topLevelRulesToDiscover: [TopLevelRuleType] = TopLevelRuleType.allCases,
+        dependencyRulesToDiscover: [DependencyRuleType] = DependencyRuleType.allCases,
     ) {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
@@ -46,5 +48,6 @@ package struct BaseServerConfig: Equatable {
         self.filesToWatch = filesToWatch
         self.compileTopLevel = compileTopLevel
         self.topLevelRulesToDiscover = topLevelRulesToDiscover
+        self.dependencyRulesToDiscover = dependencyRulesToDiscover
     }
 }

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -105,7 +105,7 @@ struct BazelTargetCompilerArgsExtractorTests {
                 topLevelParentRuleType: .iosApplication,
                 topLevelParentConfig: helloWorldConfig
             ),
-            withStrategy: .objcImpl("HelloWorld/TodoObjCSupport/Sources/SKDateDistanceCalculator.m"),
+            withStrategy: .cImpl("HelloWorld/TodoObjCSupport/Sources/SKDateDistanceCalculator.m", "objective-c"),
         )
         #expect(result == expectedObjCResult)
     }
@@ -122,7 +122,7 @@ struct BazelTargetCompilerArgsExtractorTests {
                     topLevelParentRuleType: .iosApplication,
                     topLevelParentConfig: helloWorldConfig
                 ),
-                withStrategy: .objcImpl("HelloWorld/TodoObjCSupport/Sources/SomethingElse.m"),
+                withStrategy: .cImpl("HelloWorld/TodoObjCSupport/Sources/SomethingElse.m", "objective-c"),
             )
         }
         #expect(

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
@@ -54,7 +54,7 @@ struct BazelTargetQuerierParserImplTests {
             from: exampleCqueryOutput,
             testBundleRules: testBundleRules,
             userProvidedTargets: userProvidedTargets,
-            supportedRuleKinds: SupportedRuleKind.allCases,
+            supportedDependencyRuleTypes: DependencyRuleType.allCases,
             supportedTopLevelRuleTypes: supportedTopLevelRuleTypes,
             rootUri: Self.mockRootUri,
             executionRoot: Self.mockExecutionRoot,

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
@@ -54,6 +54,7 @@ struct BazelTargetQuerierParserImplTests {
             from: exampleCqueryOutput,
             testBundleRules: testBundleRules,
             userProvidedTargets: userProvidedTargets,
+            supportedRuleKinds: SupportedRuleKind.allCases,
             supportedTopLevelRuleTypes: supportedTopLevelRuleTypes,
             rootUri: Self.mockRootUri,
             executionRoot: Self.mockExecutionRoot,
@@ -81,159 +82,90 @@ struct BazelTargetQuerierParserImplTests {
             canDebug: false
         )
 
-        #expect(result.buildTargets.count == 11)
+        let toolchainUri = try URI(string: "file://" + Self.mockToolchainPath)
+        let expectedData = SourceKitBuildTarget(toolchain: toolchainUri).encodeToLSPAny()
 
-        // Target 0: ExpandedTemplate
-        #expect(result.buildTargets[0].id == BuildTargetIdentifier(uri: expandedTemplateUri))
-        #expect(result.buildTargets[0].displayName == "//HelloWorld:ExpandedTemplate")
-        #expect(result.buildTargets[0].baseDirectory == baseDir)
-        #expect(result.buildTargets[0].tags == [.library])
-        #expect(result.buildTargets[0].languageIds == [.swift])
-        #expect(result.buildTargets[0].dependencies == [])
-        #expect(result.buildTargets[0].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[0].dataKind == .sourceKit)
+        func makeExpectedTarget(
+            uri: URI,
+            displayName: String,
+            language: Language = .swift,
+            dependencies: [URI] = []
+        ) -> BuildTarget {
+            BuildTarget(
+                id: BuildTargetIdentifier(uri: uri),
+                displayName: displayName,
+                baseDirectory: baseDir,
+                tags: [.library],
+                capabilities: expectedCapabilities,
+                languageIds: [language],
+                dependencies: dependencies.map { BuildTargetIdentifier(uri: $0) },
+                dataKind: .sourceKit,
+                data: expectedData
+            )
+        }
 
-        // Target 1: GeneratedDummy
-        #expect(result.buildTargets[1].id == BuildTargetIdentifier(uri: generatedDummyUri))
-        #expect(result.buildTargets[1].displayName == "//HelloWorld:GeneratedDummy")
-        #expect(result.buildTargets[1].baseDirectory == baseDir)
-        #expect(result.buildTargets[1].tags == [.library])
-        #expect(result.buildTargets[1].languageIds == [.swift])
-        #expect(result.buildTargets[1].dependencies == [])
-        #expect(result.buildTargets[1].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[1].dataKind == .sourceKit)
-
-        // Target 2: HelloWorldLib
-        #expect(result.buildTargets[2].id == BuildTargetIdentifier(uri: helloWorldLibUri))
-        #expect(result.buildTargets[2].displayName == "//HelloWorld:HelloWorldLib")
-        #expect(result.buildTargets[2].baseDirectory == baseDir)
-        #expect(result.buildTargets[2].tags == [.library])
-        #expect(result.buildTargets[2].languageIds == [.swift])
-        #expect(
-            result.buildTargets[2].dependencies == [
-                BuildTargetIdentifier(uri: expandedTemplateUri),
-                BuildTargetIdentifier(uri: generatedDummyUri),
-                BuildTargetIdentifier(uri: todoModelsUri),
-                BuildTargetIdentifier(uri: todoObjCSupportUri),
-            ]
-        )
-        #expect(result.buildTargets[2].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[2].dataKind == .sourceKit)
-
-        // Target 3: HelloWorldTestsLib
-        #expect(result.buildTargets[3].id == BuildTargetIdentifier(uri: helloWorldTestsLibUri))
-        #expect(result.buildTargets[3].displayName == "//HelloWorld:HelloWorldTestsLib")
-        #expect(result.buildTargets[3].baseDirectory == baseDir)
-        #expect(result.buildTargets[3].tags == [.library])
-        #expect(result.buildTargets[3].languageIds == [.swift])
-        #expect(
-            result.buildTargets[3].dependencies == [
-                BuildTargetIdentifier(uri: helloWorldLibUri)
-            ]
-        )
-        #expect(result.buildTargets[3].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[3].dataKind == .sourceKit)
-
-        // Target 4: MacAppLib
-        #expect(result.buildTargets[4].id == BuildTargetIdentifier(uri: macAppLibUri))
-        #expect(result.buildTargets[4].displayName == "//HelloWorld:MacAppLib")
-        #expect(result.buildTargets[4].baseDirectory == baseDir)
-        #expect(result.buildTargets[4].tags == [.library])
-        #expect(result.buildTargets[4].languageIds == [.swift])
-        #expect(
-            result.buildTargets[4].dependencies == [
-                BuildTargetIdentifier(uri: todoModelsUri)
-            ]
-        )
-        #expect(result.buildTargets[4].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[4].dataKind == .sourceKit)
-
-        // Target 5: MacAppTestsLib
-        #expect(result.buildTargets[5].id == BuildTargetIdentifier(uri: macAppTestsLibUri))
-        #expect(result.buildTargets[5].displayName == "//HelloWorld:MacAppTestsLib")
-        #expect(result.buildTargets[5].baseDirectory == baseDir)
-        #expect(result.buildTargets[5].tags == [.library])
-        #expect(result.buildTargets[5].languageIds == [.swift])
-        #expect(
-            result.buildTargets[5].dependencies == [
-                BuildTargetIdentifier(uri: macAppLibUri)
-            ]
-        )
-        #expect(result.buildTargets[5].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[5].dataKind == .sourceKit)
-
-        // Target 6: MacCLIAppLib
-        #expect(result.buildTargets[6].id == BuildTargetIdentifier(uri: macCLIAppLibUri))
-        #expect(result.buildTargets[6].displayName == "//HelloWorld:MacCLIAppLib")
-        #expect(result.buildTargets[6].baseDirectory == baseDir)
-        #expect(result.buildTargets[6].tags == [.library])
-        #expect(result.buildTargets[6].languageIds == [.swift])
-        #expect(
-            result.buildTargets[6].dependencies == [
-                BuildTargetIdentifier(uri: todoModelsUri)
-            ]
-        )
-        #expect(result.buildTargets[6].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[6].dataKind == .sourceKit)
-
-        // Target 7: TodoModels
-        #expect(result.buildTargets[7].id == BuildTargetIdentifier(uri: todoModelsUri))
-        #expect(result.buildTargets[7].displayName == "//HelloWorld:TodoModels")
-        #expect(result.buildTargets[7].baseDirectory == baseDir)
-        #expect(result.buildTargets[7].tags == [.library])
-        #expect(result.buildTargets[7].languageIds == [.swift])
-        #expect(result.buildTargets[7].dependencies == [])
-        #expect(result.buildTargets[7].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[7].dataKind == .sourceKit)
-
-        // Target 8: TodoObjCSupport
-        #expect(result.buildTargets[8].id == BuildTargetIdentifier(uri: todoObjCSupportUri))
-        #expect(result.buildTargets[8].displayName == "//HelloWorld:TodoObjCSupport")
-        #expect(result.buildTargets[8].baseDirectory == baseDir)
-        #expect(result.buildTargets[8].tags == [.library])
-        #expect(result.buildTargets[8].languageIds == [.objective_c])
-        #expect(result.buildTargets[8].dependencies == [])
-        #expect(result.buildTargets[8].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[8].dataKind == .sourceKit)
-
-        // Target 9: WatchAppLib
-        #expect(result.buildTargets[9].id == BuildTargetIdentifier(uri: watchAppLibUri))
-        #expect(result.buildTargets[9].displayName == "//HelloWorld:WatchAppLib")
-        #expect(result.buildTargets[9].baseDirectory == baseDir)
-        #expect(result.buildTargets[9].tags == [.library])
-        #expect(result.buildTargets[9].languageIds == [.swift])
-        #expect(
-            result.buildTargets[9].dependencies == [
-                BuildTargetIdentifier(uri: todoModelsUri)
-            ]
-        )
-        #expect(result.buildTargets[9].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[9].dataKind == .sourceKit)
-
-        // Target 10: WatchAppTestsLib
-        #expect(result.buildTargets[10].id == BuildTargetIdentifier(uri: watchAppTestsLibUri))
-        #expect(result.buildTargets[10].displayName == "//HelloWorld:WatchAppTestsLib")
-        #expect(result.buildTargets[10].baseDirectory == baseDir)
-        #expect(result.buildTargets[10].tags == [.library])
-        #expect(result.buildTargets[10].languageIds == [.swift])
-        #expect(
-            result.buildTargets[10].dependencies == [
-                BuildTargetIdentifier(uri: watchAppLibUri)
-            ]
-        )
-        #expect(result.buildTargets[10].capabilities == expectedCapabilities)
-        #expect(result.buildTargets[10].dataKind == .sourceKit)
+        let expectedBuildTargets = [
+            makeExpectedTarget(uri: expandedTemplateUri, displayName: "//HelloWorld:ExpandedTemplate"),
+            makeExpectedTarget(uri: generatedDummyUri, displayName: "//HelloWorld:GeneratedDummy"),
+            makeExpectedTarget(
+                uri: helloWorldLibUri,
+                displayName: "//HelloWorld:HelloWorldLib",
+                dependencies: [expandedTemplateUri, generatedDummyUri, todoModelsUri, todoObjCSupportUri]
+            ),
+            makeExpectedTarget(
+                uri: helloWorldTestsLibUri,
+                displayName: "//HelloWorld:HelloWorldTestsLib",
+                dependencies: [helloWorldLibUri]
+            ),
+            makeExpectedTarget(
+                uri: macAppLibUri,
+                displayName: "//HelloWorld:MacAppLib",
+                dependencies: [todoModelsUri]
+            ),
+            makeExpectedTarget(
+                uri: macAppTestsLibUri,
+                displayName: "//HelloWorld:MacAppTestsLib",
+                dependencies: [macAppLibUri]
+            ),
+            makeExpectedTarget(
+                uri: macCLIAppLibUri,
+                displayName: "//HelloWorld:MacCLIAppLib",
+                dependencies: [todoModelsUri]
+            ),
+            makeExpectedTarget(uri: todoModelsUri, displayName: "//HelloWorld:TodoModels"),
+            makeExpectedTarget(
+                uri: todoObjCSupportUri,
+                displayName: "//HelloWorld:TodoObjCSupport",
+                language: .objective_c
+            ),
+            makeExpectedTarget(
+                uri: watchAppLibUri,
+                displayName: "//HelloWorld:WatchAppLib",
+                dependencies: [todoModelsUri]
+            ),
+            makeExpectedTarget(
+                uri: watchAppTestsLibUri,
+                displayName: "//HelloWorld:WatchAppTestsLib",
+                dependencies: [watchAppLibUri]
+            ),
+        ]
+        #expect(result.buildTargets == expectedBuildTargets)
 
         // Top level targets
-        #expect(result.topLevelTargets.count == 8)
-        #expect(result.topLevelTargets[0] == ("//HelloWorld:HelloWorldMacTests", .macosUnitTest))
-        #expect(result.topLevelTargets[1] == ("//HelloWorld:HelloWorldTests", .iosUnitTest))
-        #expect(result.topLevelTargets[2] == ("//HelloWorld:HelloWorld", .iosApplication))
-        #expect(result.topLevelTargets[3] == ("//HelloWorld:HelloWorldWatchExtension", .watchosExtension))
-        #expect(result.topLevelTargets[4] == ("//HelloWorld:HelloWorldWatchTests", .watchosUnitTest))
-        #expect(result.topLevelTargets[5] == ("//HelloWorld:HelloWorldMacCLIApp", .macosCommandLineApplication))
-        #expect(result.topLevelTargets[6] == ("//HelloWorld:HelloWorldMacApp", .macosApplication))
-        #expect(result.topLevelTargets[7] == ("//HelloWorld:HelloWorldWatchApp", .watchosApplication))
+        let expectedTopLevelTargets: [(String, TopLevelRuleType)] = [
+            ("//HelloWorld:HelloWorldMacTests", .macosUnitTest),
+            ("//HelloWorld:HelloWorldTests", .iosUnitTest),
+            ("//HelloWorld:HelloWorld", .iosApplication),
+            ("//HelloWorld:HelloWorldWatchExtension", .watchosExtension),
+            ("//HelloWorld:HelloWorldWatchTests", .watchosUnitTest),
+            ("//HelloWorld:HelloWorldMacCLIApp", .macosCommandLineApplication),
+            ("//HelloWorld:HelloWorldMacApp", .macosApplication),
+            ("//HelloWorld:HelloWorldWatchApp", .watchosApplication),
+        ]
+        #expect(result.topLevelTargets.count == expectedTopLevelTargets.count)
+        for (index, expected) in expectedTopLevelTargets.enumerated() {
+            #expect(result.topLevelTargets[index] == expected)
+        }
 
         // Available Bazel labels
         #expect(
@@ -254,18 +186,17 @@ struct BazelTargetQuerierParserImplTests {
         )
 
         // Top level label to rule map
-        #expect(
-            result.topLevelLabelToRuleMap == [
-                "//HelloWorld:HelloWorld": .iosApplication,
-                "//HelloWorld:HelloWorldMacApp": .macosApplication,
-                "//HelloWorld:HelloWorldMacCLIApp": .macosCommandLineApplication,
-                "//HelloWorld:HelloWorldMacTests": .macosUnitTest,
-                "//HelloWorld:HelloWorldTests": .iosUnitTest,
-                "//HelloWorld:HelloWorldWatchApp": .watchosApplication,
-                "//HelloWorld:HelloWorldWatchExtension": .watchosExtension,
-                "//HelloWorld:HelloWorldWatchTests": .watchosUnitTest,
-            ]
-        )
+        let expectedTopLevelLabelToRuleMap: [String: TopLevelRuleType] = [
+            "//HelloWorld:HelloWorld": .iosApplication,
+            "//HelloWorld:HelloWorldMacApp": .macosApplication,
+            "//HelloWorld:HelloWorldMacCLIApp": .macosCommandLineApplication,
+            "//HelloWorld:HelloWorldMacTests": .macosUnitTest,
+            "//HelloWorld:HelloWorldTests": .iosUnitTest,
+            "//HelloWorld:HelloWorldWatchApp": .watchosApplication,
+            "//HelloWorld:HelloWorldWatchExtension": .watchosExtension,
+            "//HelloWorld:HelloWorldWatchTests": .watchosUnitTest,
+        ]
+        #expect(result.topLevelLabelToRuleMap == expectedTopLevelLabelToRuleMap)
 
         // BSP URIs to Bazel Labels map
         #expect(

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -89,12 +89,12 @@ struct BazelTargetQuerierTests {
         let config = Self.makeInitializedConfig()
 
         let expectedCommand =
-            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"source file|swift_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
+            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"cc_library|objc_library|swift_library|alias|source file\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
         runnerMock.setResponse(for: expectedCommand, cwd: Self.mockRootUri, response: exampleCqueryOutput)
 
         _ = try querier.cqueryTargets(
             config: config,
-            dependencyKinds: ["source file", "swift_library"],
+            supportedRuleKinds: SupportedRuleKind.allCases,
             supportedTopLevelRuleTypes: [.iosApplication]
         )
 
@@ -112,12 +112,12 @@ struct BazelTargetQuerierTests {
         let config = Self.makeInitializedConfig(targets: ["//HelloWorld", "//Tests"])
 
         let expectedCommand =
-            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld //Tests)) in   $topLevelTargets   union   kind(\"objc_library|swift_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
+            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld //Tests)) in   $topLevelTargets   union   kind(\"cc_library|objc_library|swift_library|alias|source file\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
         runnerMock.setResponse(for: expectedCommand, cwd: Self.mockRootUri, response: exampleCqueryOutput)
 
         _ = try querier.cqueryTargets(
             config: config,
-            dependencyKinds: ["objc_library", "swift_library"],
+            supportedRuleKinds: SupportedRuleKind.allCases,
             supportedTopLevelRuleTypes: [.iosApplication]
         )
 
@@ -136,37 +136,37 @@ struct BazelTargetQuerierTests {
 
         runnerMock.setResponse(
             for:
-                "bazel --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"swift_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto",
+                "bazel --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"swift_library|alias|source file\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto",
             cwd: Self.mockRootUri,
             response: exampleCqueryOutput
         )
         runnerMock.setResponse(
             for:
-                "bazel --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"objc_library|alias\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto",
+                "bazel --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"objc_library|alias|source file\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto",
             cwd: Self.mockRootUri,
             response: exampleCqueryOutput
         )
 
-        func run(dependencyKinds: [String]) throws {
+        func run(supportedRuleKinds: [SupportedRuleKind]) throws {
             _ = try querier.cqueryTargets(
                 config: config,
-                dependencyKinds: dependencyKinds,
+                supportedRuleKinds: supportedRuleKinds,
                 supportedTopLevelRuleTypes: [.iosApplication]
             )
         }
 
-        try run(dependencyKinds: ["swift_library"])
-        try run(dependencyKinds: ["swift_library"])
+        try run(supportedRuleKinds: [.swiftLibrary])
+        try run(supportedRuleKinds: [.swiftLibrary])
         #expect(runnerMock.commands.count == 1)
 
         // Querying something else then results in a new command
-        try run(dependencyKinds: ["objc_library"])
+        try run(supportedRuleKinds: [.objcLibrary])
         #expect(runnerMock.commands.count == 2)
-        try run(dependencyKinds: ["objc_library"])
+        try run(supportedRuleKinds: [.objcLibrary])
         #expect(runnerMock.commands.count == 2)
 
         // But the original call is still cached
-        try run(dependencyKinds: ["swift_library"])
+        try run(supportedRuleKinds: [.swiftLibrary])
         #expect(runnerMock.commands.count == 2)
     }
 
@@ -178,12 +178,12 @@ struct BazelTargetQuerierTests {
         let config = Self.makeInitializedConfig()
 
         let expectedCommand =
-            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"source file|swift_library|alias|_watchos_internal_unit_test_bundle\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
+            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"rule\", set(//HelloWorld)) in   $topLevelTargets   union   kind(\"cc_library|objc_library|swift_library|alias|source file|_watchos_internal_unit_test_bundle\", deps($topLevelTargets))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
         runnerMock.setResponse(for: expectedCommand, cwd: Self.mockRootUri, response: exampleCqueryOutput)
 
         _ = try querier.cqueryTargets(
             config: config,
-            dependencyKinds: ["source file", "swift_library"],
+            supportedRuleKinds: SupportedRuleKind.allCases,
             supportedTopLevelRuleTypes: [.iosApplication, .watchosUnitTest]
         )
 

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -94,7 +94,7 @@ struct BazelTargetQuerierTests {
 
         _ = try querier.cqueryTargets(
             config: config,
-            supportedRuleKinds: SupportedRuleKind.allCases,
+            supportedDependencyRuleTypes: DependencyRuleType.allCases,
             supportedTopLevelRuleTypes: [.iosApplication]
         )
 
@@ -117,7 +117,7 @@ struct BazelTargetQuerierTests {
 
         _ = try querier.cqueryTargets(
             config: config,
-            supportedRuleKinds: SupportedRuleKind.allCases,
+            supportedDependencyRuleTypes: DependencyRuleType.allCases,
             supportedTopLevelRuleTypes: [.iosApplication]
         )
 
@@ -147,26 +147,26 @@ struct BazelTargetQuerierTests {
             response: exampleCqueryOutput
         )
 
-        func run(supportedRuleKinds: [SupportedRuleKind]) throws {
+        func run(supportedDependencyRuleTypes: [DependencyRuleType]) throws {
             _ = try querier.cqueryTargets(
                 config: config,
-                supportedRuleKinds: supportedRuleKinds,
+                supportedDependencyRuleTypes: supportedDependencyRuleTypes,
                 supportedTopLevelRuleTypes: [.iosApplication]
             )
         }
 
-        try run(supportedRuleKinds: [.swiftLibrary])
-        try run(supportedRuleKinds: [.swiftLibrary])
+        try run(supportedDependencyRuleTypes: [.swiftLibrary])
+        try run(supportedDependencyRuleTypes: [.swiftLibrary])
         #expect(runnerMock.commands.count == 1)
 
         // Querying something else then results in a new command
-        try run(supportedRuleKinds: [.objcLibrary])
+        try run(supportedDependencyRuleTypes: [.objcLibrary])
         #expect(runnerMock.commands.count == 2)
-        try run(supportedRuleKinds: [.objcLibrary])
+        try run(supportedDependencyRuleTypes: [.objcLibrary])
         #expect(runnerMock.commands.count == 2)
 
         // But the original call is still cached
-        try run(supportedRuleKinds: [.swiftLibrary])
+        try run(supportedDependencyRuleTypes: [.swiftLibrary])
         #expect(runnerMock.commands.count == 2)
     }
 
@@ -183,7 +183,7 @@ struct BazelTargetQuerierTests {
 
         _ = try querier.cqueryTargets(
             config: config,
-            supportedRuleKinds: SupportedRuleKind.allCases,
+            supportedDependencyRuleTypes: DependencyRuleType.allCases,
             supportedTopLevelRuleTypes: [.iosApplication, .watchosUnitTest]
         )
 

--- a/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetQuerierParserFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetQuerierParserFake.swift
@@ -29,7 +29,7 @@ final class BazelTargetQuerierParserFake: BazelTargetQuerierParser {
         from data: Data,
         testBundleRules: [String],
         userProvidedTargets: [String],
-        supportedRuleKinds: [SupportedRuleKind],
+        supportedDependencyRuleTypes: [DependencyRuleType],
         supportedTopLevelRuleTypes: [TopLevelRuleType],
         rootUri: String,
         executionRoot: String,

--- a/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetQuerierParserFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetQuerierParserFake.swift
@@ -29,6 +29,7 @@ final class BazelTargetQuerierParserFake: BazelTargetQuerierParser {
         from data: Data,
         testBundleRules: [String],
         userProvidedTargets: [String],
+        supportedRuleKinds: [SupportedRuleKind],
         supportedTopLevelRuleTypes: [TopLevelRuleType],
         rootUri: String,
         executionRoot: String,


### PR DESCRIPTION
- The BSP can now parse `cc_library` types
- Fixed Obj-C targets not parsing headers correctly
- Refactored how the BSP handles supported languages and extensions
- Added a new `--dependency-rule-types-to-discover` param to allow controlling which languages the BSP should look for. Enables everything by default.
- Example project: Add examples for Obj-C++, C++, and C