### PR TITLE
Add the ability to filter targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ If this is undesirable, you can pass the `--compile-top-level` flag to make the 
 
 ## Best Practices
 
-- When working with large apps, consider being more explicit about the task you're going to do. This means that instead of importing the _entire app at all times_, try to import only a small group of test targets that you think will be required to perform the task. This will greatly increase the performance of the IDE.
+- When working with large apps, consider being more explicit about the task you're going to do. This means that instead of importing the _entire app at all times_ or running wide-reaching wildcards like `//...`, try to import only a small group of test targets that you think will be required to perform the task. This will greatly increase the performance of the IDE.
+    - The BSP's many filtering arguments can be particularly useful for more complex cases.
     - For smaller apps, this doesn't make much difference and it should be fine to import the entire app.
-- Similarly, avoid wide-reaching wildcards like `//...`. Do so only at a smaller scale to avoid too many targets from being picked up.
 
 ## Troubleshooting
 

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -32,6 +32,8 @@ package struct BaseServerConfig: Equatable {
     let compileTopLevel: Bool
     let topLevelRulesToDiscover: [TopLevelRuleType]
     let dependencyRulesToDiscover: [DependencyRuleType]
+    let topLevelTargetsToExclude: [String]
+    let dependencyTargetsToExclude: [String]
 
     package init(
         bazelWrapper: String,
@@ -41,6 +43,8 @@ package struct BaseServerConfig: Equatable {
         compileTopLevel: Bool,
         topLevelRulesToDiscover: [TopLevelRuleType] = TopLevelRuleType.allCases,
         dependencyRulesToDiscover: [DependencyRuleType] = DependencyRuleType.allCases,
+        topLevelTargetsToExclude: [String] = [],
+        dependencyTargetsToExclude: [String] = []
     ) {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
@@ -49,5 +53,7 @@ package struct BaseServerConfig: Equatable {
         self.compileTopLevel = compileTopLevel
         self.topLevelRulesToDiscover = topLevelRulesToDiscover
         self.dependencyRulesToDiscover = dependencyRulesToDiscover
+        self.topLevelTargetsToExclude = topLevelTargetsToExclude
+        self.dependencyTargetsToExclude = dependencyTargetsToExclude
     }
 }

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -65,6 +65,20 @@ struct Serve: ParsableCommand {
     )
     var compileTopLevel: Bool = false
 
+    @Option(
+        parsing: .singleValue,
+        help:
+            "A target pattern to exclude when discovering top-level targets. Can be specified multiple times."
+    )
+    var topLevelTargetToExclude: [String] = []
+
+    @Option(
+        parsing: .singleValue,
+        help:
+            "A target pattern to exclude when discovering dependency targets. Can be specified multiple times."
+    )
+    var dependencyTargetToExclude: [String] = []
+
     func run() throws {
         logger.info("`serve` invoked, initializing BSP server...")
 
@@ -82,7 +96,9 @@ struct Serve: ParsableCommand {
             filesToWatch: filesToWatch,
             compileTopLevel: compileTopLevel,
             topLevelRulesToDiscover: topLevelRulesToDiscover,
-            dependencyRulesToDiscover: dependencyRulesToDiscover
+            dependencyRulesToDiscover: dependencyRulesToDiscover,
+            topLevelTargetsToExclude: topLevelTargetToExclude,
+            dependencyTargetsToExclude: dependencyTargetToExclude
         )
 
         logger.debug("Initializing BSP with targets: \(targets)")

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -22,6 +22,12 @@ def _setup_sourcekit_bsp_impl(ctx):
     for top_level_rule in ctx.attr.top_level_rules_to_discover:
         bsp_config_argv.append("--top-level-rule-to-discover")
         bsp_config_argv.append(top_level_rule)
+    for target in ctx.attr.top_level_targets_to_exclude:
+        bsp_config_argv.append("--top-level-target-to-exclude")
+        bsp_config_argv.append(target)
+    for target in ctx.attr.dependency_targets_to_exclude:
+        bsp_config_argv.append("--dependency-target-to-exclude")
+        bsp_config_argv.append(target)
     files_to_watch = ",".join(ctx.attr.files_to_watch)
     if files_to_watch:
         bsp_config_argv.append("--files-to-watch")
@@ -115,6 +121,14 @@ setup_sourcekit_bsp = rule(
         ),
         "top_level_rules_to_discover": attr.string_list(
             doc = "A list of top-level rule types to discover targets for (e.g. 'ios_application', 'ios_unit_test'). If not specified, all supported top-level rule types will be used for target discovery.",
+            default = [],
+        ),
+        "top_level_targets_to_exclude": attr.string_list(
+            doc = "A list of target patterns to exclude from top-level targets in the cquery.",
+            default = [],
+        ),
+        "dependency_targets_to_exclude": attr.string_list(
+            doc = "A list of target patterns to exclude from dependency targets in the cquery.",
             default = [],
         ),
         "index_build_batch_size": attr.int(


### PR DESCRIPTION
Adds two new arguments that allow further filtering of the final targets list when using wildcards.

- `--top-level-target-to-exclude`, to filter targets from the top-level list
- `--dependency-target-to-exclude`, to filter targets from the parsed dependency lists.