### PR TITLE
Write a JSON report after parsing targets

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
@@ -17,18 +17,26 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import BuildServerProtocol
 import Foundation
-import LanguageServerProtocol
 
-private let logger = makeFileLevelBSPLogger()
+/// A report containing all parsed targets from the build graph.
+/// Written as JSON after buildTargets completes.
+struct BazelTargetGraphReport: Codable, Equatable {
 
-struct ProcessedCqueryResult {
-    let buildTargets: [BuildTarget]
-    let topLevelTargets: [(String, TopLevelRuleType)]
-    let bspURIsToBazelLabelsMap: [URI: String]
-    let bspURIsToSrcsMap: [URI: SourcesItem]
-    let srcToBspURIsMap: [URI: [URI]]
-    let topLevelLabelToRuleMap: [String: TopLevelRuleType]
-    let bazelLabelToParentsMap: [String: [String]]
+    struct TopLevelTarget: Codable, Equatable {
+        let label: String
+        let ruleType: String
+        let platform: String
+        let minimumOsVersion: String
+        let cpuArch: String
+        let isTest: Bool
+    }
+
+    struct DependencyTarget: Codable, Equatable {
+        let label: String
+        let parents: [String]
+    }
+
+    let topLevelTargets: [TopLevelTarget]
+    let dependencyTargets: [DependencyTarget]
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -165,6 +165,8 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
             throw BazelTargetQuerierParserError.noTopLevelTargets(supportedTopLevelRuleTypes)
         }
 
+        logger.logFullObjectInMultipleLogMessages(level: .info, header: "Top-level targets", String(topLevelTargets.map { $0.0.rule.name }.joined(separator: ", ")))
+
         // Start by pre-processing all of the provided source files into a map for quick lookup.
         var srcToUriMap: [String: URI] = [:]
         for target in allSrcs {
@@ -320,7 +322,6 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
         var bspURIsToBazelLabelsMap: [URI: String] = [:]
         var bspURIsToSrcsMap: [URI: SourcesItem] = [:]
         var srcToBspURIsMap: [URI: [URI]] = [:]
-        var availableBazelLabels: Set<String> = []
         var topLevelLabelToRuleMap: [String: TopLevelRuleType] = [:]
         for dependencyTargetInfo in buildTargets {
             let target = dependencyTargetInfo.value.0
@@ -332,7 +333,6 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
             let uri = target.id.uri
             bspURIsToBazelLabelsMap[uri] = displayName
             bspURIsToSrcsMap[uri] = sourcesItem
-            availableBazelLabels.insert(displayName)
             for src in sourcesItem.sources {
                 srcToBspURIsMap[src.uri, default: []].append(uri)
             }
@@ -348,7 +348,6 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
             bspURIsToBazelLabelsMap: bspURIsToBazelLabelsMap,
             bspURIsToSrcsMap: bspURIsToSrcsMap,
             srcToBspURIsMap: srcToBspURIsMap,
-            availableBazelLabels: availableBazelLabels,
             topLevelLabelToRuleMap: topLevelLabelToRuleMap,
             bazelLabelToParentsMap: bazelLabelToParentsMap
         )

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
@@ -154,24 +154,6 @@ struct BazelTargetQuerierParserImplTests {
             #expect(result.topLevelTargets[index] == expected)
         }
 
-        // Available Bazel labels
-        #expect(
-            result.availableBazelLabels
-                == Set([
-                    "//HelloWorld:ExpandedTemplate",
-                    "//HelloWorld:GeneratedDummy",
-                    "//HelloWorld:HelloWorldLib",
-                    "//HelloWorld:HelloWorldTestsLib",
-                    "//HelloWorld:MacAppLib",
-                    "//HelloWorld:MacAppTestsLib",
-                    "//HelloWorld:MacCLIAppLib",
-                    "//HelloWorld:TodoModels",
-                    "//HelloWorld:TodoObjCSupport",
-                    "//HelloWorld:WatchAppLib",
-                    "//HelloWorld:WatchAppTestsLib",
-                ])
-        )
-
         // Top level label to rule map
         let expectedTopLevelLabelToRuleMap: [String: TopLevelRuleType] = [
             "//HelloWorld:HelloWorld": .iosApplication,

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -33,7 +33,6 @@ struct BazelTargetQuerierTests {
         bspURIsToBazelLabelsMap: [:],
         bspURIsToSrcsMap: [:],
         srcToBspURIsMap: [:],
-        availableBazelLabels: [],
         topLevelLabelToRuleMap: [:],
         bazelLabelToParentsMap: [:]
     )


### PR DESCRIPTION
This makes it so that the BSP will now write a JSON to "output path + sourcekit-bazel-bsp-graph.json" containing a detailed list of everything that was parsed. The intention is that this can be used to power external IDE extensions to provide things such as simulator lists and build / launch tasks.

Ideally we in the future might want to go for a JSONRPC solution similar to how the BSP itself works, but writing a simple file for now just to make sure something can be done right now.