### PR TITLE
Fix test targets failing to be parsed properly

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -88,12 +88,12 @@ final class BazelTargetQuerier {
         // Always fetch source information.
         // FIXME: Need to also handle `generated file`
         dependencyKindsFilter.append("source file")
-
-        var topLevelKindsFilter = supportedTopLevelRuleTypes.map { $0.rawValue }
         // If we're searching for test rules, we need to also include their test bundle rules.
         // Otherwise we won't be able to map test dependencies back to their top level parents.
         let testBundleRules = supportedTopLevelRuleTypes.compactMap { $0.testBundleRule }
-        topLevelKindsFilter.append(contentsOf: testBundleRules)
+        dependencyKindsFilter.append(contentsOf: testBundleRules)
+
+        let topLevelKindsFilter = supportedTopLevelRuleTypes.map { $0.rawValue }
 
         // Collect the top-level targets -> collect these targets' dependencies
         let providedTargetsQuerySet = "set(\(userProvidedTargets.joined(separator: " ")))"

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -265,7 +265,7 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
                 // The cquery seems to pick up things that have the expected name somewhere within the string, like
                 // my_custom_swift_library. Ignore those
                 logger.warning(
-                    "Skipping target \(rule.name, privacy: .public) with unexpected rule class: \(rule.ruleClass). This can also happen if you used --dependency-rule-to-discover flag is set to filter this type."
+                    "Skipping target \(rule.name, privacy: .public) with unexpected rule class: \(rule.ruleClass). This can also happen if the BSP was configured to filter this type."
                 )
                 continue
             }
@@ -309,7 +309,7 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
                 // If we don't know how to parse the full path to a target, we need to drop it.
                 // Otherwise we will not know how to properly communicate this target's capabilities to sourcekit-lsp.
                 logger.warning(
-                    "Skipping orphan target \(label, privacy: .public). This can happen if the target is a dependency of a test host or of something we don't know how to parse."
+                    "Skipping orphan target \(label, privacy: .public). This can happen if the target is a dependency of a test host, of something we don't know how to parse, or if the BSP was configured to filter this target's parent(s)."
                 )
                 result[label] = nil
             }

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -181,7 +181,7 @@ struct BazelTargetQuerierTests {
         let config = Self.makeInitializedConfig()
 
         let expectedCommand =
-            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"ios_application|watchos_unit_test|_watchos_internal_unit_test_bundle\", set(//HelloWorld)) in   $topLevelTargets   union   (kind(\"swift_library|objc_library|cc_library|alias|source file\", deps($topLevelTargets)))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
+            "bazelisk --output_base=/path/to/output/base cquery \'let topLevelTargets = kind(\"ios_application|watchos_unit_test\", set(//HelloWorld)) in   $topLevelTargets   union   (kind(\"swift_library|objc_library|cc_library|alias|source file|_watchos_internal_unit_test_bundle\", deps($topLevelTargets)))\' --noinclude_aspects --notool_deps --noimplicit_deps --output proto --config=test"
         runnerMock.setResponse(for: expectedCommand, cwd: Self.mockRootUri, response: exampleCqueryOutput)
 
         _ = try querier.cqueryTargets(


### PR DESCRIPTION
When querying test bundles, the internal test bundle rule needs to be parsed as part of the query that handles dependencies, not the top-level ones.