### PR TITLE
Add support for parsing external repos and implementation_deps

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -143,6 +143,7 @@ final class BazelTargetQuerier {
             supportedDependencyRuleTypes: supportedDependencyRuleTypes,
             supportedTopLevelRuleTypes: supportedTopLevelRuleTypes,
             rootUri: config.rootUri,
+            workspaceName: config.workspaceName,
             executionRoot: config.executionRoot,
             toolchainPath: config.devToolchainPath,
         )

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -109,6 +109,10 @@ final class InitializeHandler {
         )
         logger.debug("executionRoot: \(executionRoot, privacy: .public)")
 
+        // The workspace name is the last component of the execution root path.
+        let workspaceName = URL(fileURLWithPath: executionRoot).lastPathComponent
+        logger.debug("workspaceName: \(workspaceName, privacy: .public)")
+
         // Collecting the rest of the env's details
         let devDir: String = try commandRunner.run("xcode-select --print-path")
         let xcodeVersion: String = try commandRunner.run(
@@ -125,6 +129,7 @@ final class InitializeHandler {
         return InitializedServerConfig(
             baseConfig: baseConfig,
             rootUri: rootUri,
+            workspaceName: workspaceName,
             outputBase: outputBase,
             outputPath: outputPath,
             devDir: devDir,

--- a/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
@@ -24,6 +24,7 @@ import Foundation
 struct InitializedServerConfig: Equatable {
     let baseConfig: BaseServerConfig
     let rootUri: String
+    let workspaceName: String
     let outputBase: String
     let outputPath: String
     let devDir: String

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -64,6 +64,7 @@ struct BazelTargetCompilerArgsExtractorTests {
                 compileTopLevel: compileTopLevel
             ),
             rootUri: mockRootUri,
+            workspaceName: "_main",
             outputBase: mockOutputBase,
             outputPath: mockOutputPath,
             devDir: mockDevDir,
@@ -239,7 +240,7 @@ let expectedSwiftResult: [String] = [
     "-Xfrontend",
     "-const-gather-protocols-file",
     "-Xfrontend",
-    "/private/var/tmp/_bazel_user/hash123/external/rules_swift+/swift/toolchains/config/const_protocols_to_gather.json",
+    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/external/rules_swift+/swift/toolchains/config/const_protocols_to_gather.json",
     "-DDEBUG",
     "-Onone",
     "-whole-module-optimization",

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
@@ -28,6 +28,7 @@ import Testing
 struct BazelTargetQuerierParserImplTests {
 
     private static let mockRootUri = "/path/to/project"
+    private static let mockWorkspaceName = "_main"
     private static let mockExecutionRoot = "/tmp/execroot/_main"
     private static let mockToolchainPath = "/path/to/toolchain"
 
@@ -44,23 +45,24 @@ struct BazelTargetQuerierParserImplTests {
             supportedDependencyRuleTypes: DependencyRuleType.allCases,
             supportedTopLevelRuleTypes: supportedTopLevelRuleTypes,
             rootUri: Self.mockRootUri,
+            workspaceName: Self.mockWorkspaceName,
             executionRoot: Self.mockExecutionRoot,
             toolchainPath: Self.mockToolchainPath
         )
 
         // Pre-create URIs
-        let baseDir = try URI(string: "file:///path/to/project/HelloWorld")
-        let expandedTemplateUri = try URI(string: "file:///path/to/project/HelloWorld___ExpandedTemplate")
-        let generatedDummyUri = try URI(string: "file:///path/to/project/HelloWorld___GeneratedDummy")
-        let helloWorldLibUri = try URI(string: "file:///path/to/project/HelloWorld___HelloWorldLib")
-        let helloWorldTestsLibUri = try URI(string: "file:///path/to/project/HelloWorld___HelloWorldTestsLib")
-        let macAppLibUri = try URI(string: "file:///path/to/project/HelloWorld___MacAppLib")
-        let macAppTestsLibUri = try URI(string: "file:///path/to/project/HelloWorld___MacAppTestsLib")
-        let macCLIAppLibUri = try URI(string: "file:///path/to/project/HelloWorld___MacCLIAppLib")
-        let todoModelsUri = try URI(string: "file:///path/to/project/HelloWorld___TodoModels")
-        let todoObjCSupportUri = try URI(string: "file:///path/to/project/HelloWorld___TodoObjCSupport")
-        let watchAppLibUri = try URI(string: "file:///path/to/project/HelloWorld___WatchAppLib")
-        let watchAppTestsLibUri = try URI(string: "file:///path/to/project/HelloWorld___WatchAppTestsLib")
+        let baseDir = try URI(string: "file:///path/to/project/HelloWorld/")
+        let expandedTemplateUri = try URI(string: "file:///path/to/project/HelloWorld/ExpandedTemplate")
+        let generatedDummyUri = try URI(string: "file:///path/to/project/HelloWorld/GeneratedDummy")
+        let helloWorldLibUri = try URI(string: "file:///path/to/project/HelloWorld/HelloWorldLib")
+        let helloWorldTestsLibUri = try URI(string: "file:///path/to/project/HelloWorld/HelloWorldTestsLib")
+        let macAppLibUri = try URI(string: "file:///path/to/project/HelloWorld/MacAppLib")
+        let macAppTestsLibUri = try URI(string: "file:///path/to/project/HelloWorld/MacAppTestsLib")
+        let macCLIAppLibUri = try URI(string: "file:///path/to/project/HelloWorld/MacCLIAppLib")
+        let todoModelsUri = try URI(string: "file:///path/to/project/HelloWorld/TodoModels")
+        let todoObjCSupportUri = try URI(string: "file:///path/to/project/HelloWorld/TodoObjCSupport")
+        let watchAppLibUri = try URI(string: "file:///path/to/project/HelloWorld/WatchAppLib")
+        let watchAppTestsLibUri = try URI(string: "file:///path/to/project/HelloWorld/WatchAppTestsLib")
 
         let expectedCapabilities = BuildTargetCapabilities(
             canCompile: true,
@@ -97,7 +99,7 @@ struct BazelTargetQuerierParserImplTests {
             makeExpectedTarget(
                 uri: helloWorldLibUri,
                 displayName: "//HelloWorld:HelloWorldLib",
-                dependencies: [expandedTemplateUri, generatedDummyUri, todoModelsUri, todoObjCSupportUri]
+                dependencies: [todoModelsUri, todoObjCSupportUri, expandedTemplateUri, generatedDummyUri]
             ),
             makeExpectedTarget(
                 uri: helloWorldTestsLibUri,

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -63,6 +63,7 @@ struct BazelTargetQuerierTests {
         return InitializedServerConfig(
             baseConfig: baseConfig,
             rootUri: mockRootUri,
+            workspaceName: "_main",
             outputBase: "/path/to/output/base",
             outputPath: "/path/to/output/path",
             devDir: "/path/to/dev/dir",

--- a/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetQuerierParserFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetQuerierParserFake.swift
@@ -31,6 +31,7 @@ final class BazelTargetQuerierParserFake: BazelTargetQuerierParser {
         supportedDependencyRuleTypes: [DependencyRuleType],
         supportedTopLevelRuleTypes: [TopLevelRuleType],
         rootUri: String,
+        workspaceName: String,
         executionRoot: String,
         toolchainPath: String
     ) throws -> ProcessedCqueryResult {

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -77,6 +77,7 @@ struct InitializeHandlerTests {
                 == InitializedServerConfig(
                     baseConfig: baseConfig,
                     rootUri: rootUri,
+                    workspaceName: "_main",
                     outputBase: outputBase + "-sourcekit-bazel-bsp",
                     outputPath: outputPath,
                     devDir: devDir,

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -43,6 +43,7 @@ struct PrepareHandlerTests {
         let initializedConfig = InitializedServerConfig(
             baseConfig: baseConfig,
             rootUri: "/path/to/project",
+            workspaceName: "_main",
             outputBase: "/tmp/output_base",
             outputPath: "/tmp/output_path",
             devDir: "/Applications/Xcode.app/Contents/Developer",


### PR DESCRIPTION
The BSP initially only worked with local content, but this PR makes it so that it now also works with libraries coming from external Bazel repos. This also fixes the dependency parsing not including the implementation_deps field.