### PR TITLE
Add dependency_rules_to_discover to the bazel setup, minor fixes

### DIFF
--- a/Example/HelloWorld/BUILD
+++ b/Example/HelloWorld/BUILD
@@ -250,7 +250,11 @@ setup_sourcekit_bsp(
     files_to_watch = [
         "HelloWorld/**/*.swift",
         "HelloWorld/**/*.h",
-        "HelloWorld/**/*.m"
+        "HelloWorld/**/*.m",
+        "HelloWorld/**/*.mm",
+        "HelloWorld/**/*.c",
+        "HelloWorld/**/*.hpp",
+        "HelloWorld/**/*.cpp"
     ],
     index_flags = [
         "config=index_build",

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -296,7 +296,7 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
                 depLabelToUriMap: depLabelToUriMap
             )
 
-            // These settings serve no particular purpose today. They are ignored by sourcekit-lsp.
+            // AFAIK these settings serve no particular purpose today and are ignored by sourcekit-lsp.
             let capabilities = BuildTargetCapabilities(
                 canCompile: true,
                 canTest: false,
@@ -304,11 +304,20 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
                 canDebug: false
             )
 
+            let isExternal = rule.name.hasPrefix("@")
+            let tags: [BuildTargetTag] = {
+                var tags: [BuildTargetTag] = [.library]
+                if isExternal {
+                    tags.append(.dependency)
+                }
+                return tags
+            }()
+
             let buildTarget = BuildTarget(
                 id: id,
                 displayName: rule.name,
                 baseDirectory: baseDirectory,
-                tags: [.library],
+                tags: tags,
                 capabilities: capabilities,
                 languageIds: [ruleType.language],
                 dependencies: deps,

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -68,14 +68,14 @@ struct Serve: ParsableCommand {
     @Option(
         parsing: .singleValue,
         help:
-            "A target pattern to exclude when discovering top-level targets. Can be specified multiple times."
+            "A target pattern to exclude when discovering top-level targets. Can be specified multiple times. Wildcards are supported (e.g. //foo/...)."
     )
     var topLevelTargetToExclude: [String] = []
 
     @Option(
         parsing: .singleValue,
         help:
-            "A target pattern to exclude when discovering dependency targets. Can be specified multiple times."
+            "A target pattern to exclude when discovering dependency targets. Can be specified multiple times. Wildcards are supported (e.g. //foo/...)."
     )
     var dependencyTargetToExclude: [String] = []
 

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -22,6 +22,9 @@ def _setup_sourcekit_bsp_impl(ctx):
     for top_level_rule in ctx.attr.top_level_rules_to_discover:
         bsp_config_argv.append("--top-level-rule-to-discover")
         bsp_config_argv.append(top_level_rule)
+    for dependency_rule in ctx.attr.dependency_rules_to_discover:
+        bsp_config_argv.append("--dependency-rule-to-discover")
+        bsp_config_argv.append(dependency_rule)
     for target in ctx.attr.top_level_targets_to_exclude:
         bsp_config_argv.append("--top-level-target-to-exclude")
         bsp_config_argv.append(target)
@@ -123,12 +126,16 @@ setup_sourcekit_bsp = rule(
             doc = "A list of top-level rule types to discover targets for (e.g. 'ios_application', 'ios_unit_test'). If not specified, all supported top-level rule types will be used for target discovery.",
             default = [],
         ),
+        "dependency_rules_to_discover": attr.string_list(
+            doc = "A list of dependency rule types to discover targets for (e.g. 'swift_library', 'objc_library', 'cc_library'). If not specified, all supported dependency rule types will be used for target discovery.",
+            default = [],
+        ),
         "top_level_targets_to_exclude": attr.string_list(
-            doc = "A list of target patterns to exclude from top-level targets in the cquery.",
+            doc = "A list of target patterns to exclude from top-level targets in the cquery. Wildcards are supported (e.g. //foo/...).",
             default = [],
         ),
         "dependency_targets_to_exclude": attr.string_list(
-            doc = "A list of target patterns to exclude from dependency targets in the cquery.",
+            doc = "A list of target patterns to exclude from dependency targets in the cquery. Wildcards are supported (e.g. //foo/...).",
             default = [],
         ),
         "index_build_batch_size": attr.int(


### PR DESCRIPTION
Some minor fixes before drafting a new release
- dependency_rules_to_discover was missing from the Bazel setup side of things
- Example project: Add the missing watched extensions
- Tag external dependencies (has no effect, but nice to do anyway)