### PR TITLE
Skip updating config.json when content is unchanged

### DIFF
--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -18,8 +18,11 @@ target_lsp_config_path="$lsp_folder_path/config.json"
 
 cp "$bsp_config_path" "$target_bsp_config_path"
 
+# If files are identical, do nothing
+if [ -f "$target_lsp_config_path" ] && cmp -s "$lsp_config_path" "$target_lsp_config_path"; then
+    :
 # Merge LSP config if jq is available and existing config exists
-if [ -f "$target_lsp_config_path" ] && command -v jq &> /dev/null; then
+elif [ -f "$target_lsp_config_path" ] && command -v jq &> /dev/null; then
     jq -S -s '.[0] * .[1]' "$target_lsp_config_path" "$lsp_config_path" > "$target_lsp_config_path.tmp"
     mv "$target_lsp_config_path.tmp" "$target_lsp_config_path"
 else


### PR DESCRIPTION
## Problem

The `setup_sourcekit_bsp` rule implementation unconditionally overwrites `.sourcekit-lsp/config.json` via `mv` or `cp`,
even when the file content hasn't changed. This triggers file system watchers, causing the Swift extension to prompt users to restart LSP server every time the rule is executed, even if the config didn't in fact change, this creates some confusion for the user and/or makes users restart LSP server more than needed.

<img width="354" height="123" alt="image" src="https://github.com/user-attachments/assets/fb47e9be-b4a9-404f-8583-ac079d12f8a4" />

## Solution

Check if the source and target `config.json` files are identical using `cmp -s` before
performing any write operations. If the files are identical, skip the update entirely.