### PR TITLE
Update graph json path and fields

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
@@ -24,9 +24,12 @@ import Foundation
 struct BazelTargetGraphReport: Codable, Equatable {
 
     struct TopLevelTarget: Codable, Equatable {
+        enum LaunchType: String, Codable, Equatable {
+            case app
+            case test
+        }
         let label: String
-        let ruleType: String
-        let isTest: Bool
+        let launchType: LaunchType
         let configId: UInt32
     }
 


### PR DESCRIPTION
- Writes the graph json to a more predictable `.bsp/skbsp_generated/graph.json` path
- Removes ruleType and adds a new `launchType` (makes IDE integrations easier to implement)