### PR TITLE
Fix BSP not working with rules_apple 4.3.3

### DIFF
--- a/Example/.bazelrc
+++ b/Example/.bazelrc
@@ -1,5 +1,6 @@
 common --ios_simulator_device="iPhone 16 Pro"
 common --ios_simulator_version="18.6"
+common --watchos_cpus=arm64
 
 # rules_swift flags migration
 # --swiftcopt and --host_swiftcopt are deprecated

--- a/Example/MODULE.bazel
+++ b/Example/MODULE.bazel
@@ -6,13 +6,13 @@ local_path_override(
 
 bazel_dep(
     name = "rules_swift",
-    version = "3.3.0",
+    version = "3.4.0",
     repo_name = "build_bazel_rules_swift",
 )
 
 bazel_dep(
     name = "rules_apple",
-    version = "4.3.2",
+    version = "4.3.3",
     repo_name = "build_bazel_rules_apple",
 )
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -584,11 +584,17 @@ extension BazelTargetQuerierParserImpl {
         let cpuComponents = try configComponents.getIndexThrowing(0).split(separator: "_", maxSplits: 1)
         let platform = try cpuComponents.getIndexThrowing(0)
         let cpuArch = try cpuComponents.getIndexThrowing(1)
+
         // To support compiling libraries directly, we need to additionally strip out
         // the transition and distinguisher parts of the configuration name, as those will not
         // be present when compiling directly.
-        let configWithoutTransitionOrDistinguisher = configComponents.dropLast(3)
+
+        // Edge case: rules_apple 4.3.3 dropped configuration distinguishers
+        let stepsToDrop = try configComponents.getIndexThrowing(5).hasPrefix("applebin_") ? 3 : 2
+
+        let configWithoutTransitionOrDistinguisher = configComponents.dropLast(stepsToDrop)
         let effectiveConfigurationName = configWithoutTransitionOrDistinguisher.joined(separator: "-")
+
         return BazelTargetConfigurationInfo(
             configurationName: fullConfig,
             effectiveConfigurationName: effectiveConfigurationName,


### PR DESCRIPTION
The format of the configuration name changed, so we need to add an edge-case check here now.