### PR TITLE
Add support for multiple target variants, improve SDK path handling

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
@@ -43,6 +43,7 @@ struct BazelTargetGraphReport: Codable, Equatable {
         let platform: String
         let minimumOsVersion: String
         let cpuArch: String
+        let sdkName: String
     }
 
     let topLevelTargets: [TopLevelTarget]

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetPlatformInfo.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetPlatformInfo.swift
@@ -25,12 +25,7 @@ import Foundation
 struct BazelTargetPlatformInfo {
     let label: String
     let topLevelParentLabel: String
-    let topLevelParentRuleType: TopLevelRuleType
     let topLevelParentConfig: BazelTargetConfigurationInfo
-
-    var platformSdkName: String {
-        topLevelParentRuleType.sdkName
-    }
 }
 
 // Information about a target's Bazel configuration, used to determine
@@ -48,4 +43,5 @@ struct BazelTargetConfigurationInfo: Hashable {
     let minimumOsVersion: String
     let platform: String
     let cpuArch: String
+    let sdkName: String
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -155,7 +155,7 @@ final class BazelTargetQuerier {
 
     /// Runs an aquery across the codebase over a list of specific target dependencies.
     func aquery(
-        topLevelTargets: [(String, TopLevelRuleType)],
+        topLevelTargets: [(String, TopLevelRuleType, UInt32)],
         config: InitializedServerConfig,
         mnemonics: [String]
     ) throws -> ProcessedAqueryResult {

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -47,7 +47,8 @@ enum BazelTargetQuerierParserError: Error, LocalizedError {
         case .parentActionNotFound(let parent, let id):
             return "Parent action \(id) for parent \(parent) not found in the aquery output."
         case .multipleParentActions(let parent):
-            return "Multiple parent actions found for \(parent) in the aquery output. This means your project is building multiple variants of the same top-level target, which the BSP cannot handle today."
+            return
+                "Multiple parent actions found for \(parent) in the aquery output. This means your project is building multiple variants of the same top-level target, which the BSP cannot handle today."
         case .configurationNotFound(let id):
             return "Configuration \(id) not found in the aquery output."
         case .sdkNameNotFound(let label):
@@ -471,7 +472,9 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
             }
             // When a dependency is available over multiple configs, we need to find the one matching the parent.
             guard let depUri = depUris.first(where: { $0.1 == config }) else {
-                logger.info("No dependency found for \(label) with config \(config). Falling back to first available config.")
+                logger.info(
+                    "No dependency found for \(label) with config \(config). Falling back to first available config."
+                )
                 return depUris.first?.0
             }
             return depUri.0
@@ -570,7 +573,8 @@ extension BazelTargetQuerierParserImpl {
         guard let fullConfig = aqueryConfigurations[configId]?.mnemonic else {
             throw BazelTargetQuerierParserError.configurationNotFound(configId)
         }
-        guard let sdkName = parentAction.environmentVariables.first(where: { $0.key == "APPLE_SDK_PLATFORM" })?.value else {
+        guard let sdkName = parentAction.environmentVariables.first(where: { $0.key == "APPLE_SDK_PLATFORM" })?.value
+        else {
             throw BazelTargetQuerierParserError.sdkNameNotFound(effectiveParentLabel)
         }
         let configComponents = fullConfig.components(separatedBy: "-")
@@ -620,7 +624,12 @@ extension String {
     /// For local labels: file://<path-to-root>/<package-name>___<target-name>
     /// For external labels: file://<execution-root>/external/<repo-name>/<package-name>___<target-name>
     ///
-    fileprivate func toTargetId(rootUri: String, workspaceName: String, executionRoot: String, config: UInt32) throws -> URI {
+    fileprivate func toTargetId(
+        rootUri: String,
+        workspaceName: String,
+        executionRoot: String,
+        config: UInt32
+    ) throws -> URI {
         let (repoName, packageName, targetName) = try splitTargetLabel(workspaceName: workspaceName)
         let packagePath = packageName.isEmpty ? "" : "/" + packageName
         let path: String
@@ -628,7 +637,9 @@ extension String {
             path = "file://" + rootUri + packagePath + "/" + targetName + "_" + String(config)
         } else {
             // External repo: use execution root + external path
-            path = "file://" + executionRoot + "/external/" + repoName + packagePath + "/" + targetName + "_" + String(config)
+            path =
+                "file://" + executionRoot + "/external/" + repoName + packagePath + "/" + targetName + "_"
+                + String(config)
         }
         guard let uri = try? URI(string: path) else {
             throw BazelTargetQuerierParserError.convertUriFailed(path)

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedAqueryResult.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedAqueryResult.swift
@@ -28,5 +28,5 @@ struct ProcessedAqueryResult: Hashable {
     let targets: [String: Analysis_Target]
     let actions: [UInt32: [Analysis_Action]]
     let configurations: [UInt32: Analysis_Configuration]
-    let topLevelLabelToConfigMap: [String: BazelTargetConfigurationInfo]
+    let topLevelConfigIdToInfoMap: [UInt32: BazelTargetConfigurationInfo]
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedCqueryResult.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedCqueryResult.swift
@@ -25,11 +25,10 @@ private let logger = makeFileLevelBSPLogger()
 
 struct ProcessedCqueryResult {
     let buildTargets: [BuildTarget]
-    let topLevelTargets: [(String, TopLevelRuleType)]
+    let topLevelTargets: [(String, TopLevelRuleType, UInt32)]
     let bspURIsToBazelLabelsMap: [URI: String]
     let bspURIsToSrcsMap: [URI: SourcesItem]
     let srcToBspURIsMap: [URI: [URI]]
-    let topLevelLabelToRuleMap: [String: TopLevelRuleType]
     let configurationToTopLevelLabelsMap: [UInt32: [String]]
-    let bazelLabelToParentConfigMap: [String: UInt32]
+    let bspUriToParentConfigMap: [URI: UInt32]
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
@@ -99,38 +99,4 @@ public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument, Senda
         default: return false
         }
     }
-
-    // FIXME: Not the best way to handle this as we need to eventually
-    // handle device builds as well
-    var sdkName: String {
-        switch self {
-        case .iosApplication: return "iphonesimulator"
-        case .iosAppClip: return "iphonesimulator"
-        case .iosExtension: return "iphonesimulator"
-        case .iosUnitTest: return "iphonesimulator"
-        case .iosUiTest: return "iphonesimulator"
-        case .iosBuildTest: return "iphonesimulator"
-        case .watchosApplication: return "watchsimulator"
-        case .watchosExtension: return "watchsimulator"
-        case .watchosUnitTest: return "watchsimulator"
-        case .watchosUiTest: return "watchsimulator"
-        case .watchosBuildTest: return "watchsimulator"
-        case .macosApplication: return "macosx"
-        case .macosExtension: return "macosx"
-        case .macosCommandLineApplication: return "macosx"
-        case .macosUnitTest: return "macosx"
-        case .macosUiTest: return "macosx"
-        case .macosBuildTest: return "macosx"
-        case .tvosApplication: return "appletvsimulator"
-        case .tvosExtension: return "appletvsimulator"
-        case .tvosUnitTest: return "appletvsimulator"
-        case .tvosUiTest: return "appletvsimulator"
-        case .tvosBuildTest: return "appletvsimulator"
-        case .visionosApplication: return "xrsimulator"
-        case .visionosExtension: return "xrsimulator"
-        case .visionosUnitTest: return "xrsimulator"
-        case .visionosUiTest: return "xrsimulator"
-        case .visionosBuildTest: return "xrsimulator"
-        }
-    }
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -154,7 +154,17 @@ final class InitializeHandler {
     }
 
     func getSDKRootPaths(with commandRunner: CommandRunner) -> [String: String] {
-        let supportedSDKTypes = Set(baseConfig.topLevelRulesToDiscover.map { $0.sdkName }).sorted()
+        let supportedSDKTypes = [
+            "appletvsimulator",
+            "appletvos",
+            "iphonesimulator",
+            "iphoneos",
+            "macosx",
+            "watchsimulator",
+            "watchos",
+            "xrsimulator",
+            "xros",
+        ]
         let sdkRootPaths: [String: String] = supportedSDKTypes.reduce(into: [:]) { result, sdkType in
             // This will fail if the user doesn't have the SDK installed, which is fine.
             guard let sdkRootPath: String? = try? commandRunner.run("xcrun --sdk \(sdkType) --show-sdk-path") else {

--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -68,7 +68,7 @@ final class PrepareHandler {
     ) {
         let targetsToBuild = request.targets
         guard !targetsToBuild.isEmpty else {
-            logger.info("No targets to build.")
+            logger.debug("No targets to build.")
             reply(.success(VoidResponse()))
             return
         }
@@ -143,9 +143,9 @@ final class PrepareHandler {
         completion: @escaping ((ResponseError?) -> Void)
     ) throws {
         if labelsToBuild.count == 1 {
-            logger.info("Will build \(labelsToBuild[0].joined(separator: ", "), privacy: .public)")
+            logger.debug("Will build \(labelsToBuild[0].joined(separator: ", "), privacy: .public)")
         } else {
-            logger.info(
+            logger.debug(
                 "Will build \(labelsToBuild.flatMap { $0 }.joined(separator: ", "), privacy: .public) over \(labelsToBuild.count, privacy: .public) invocations"
             )
         }
@@ -175,11 +175,11 @@ final class PrepareHandler {
             )
             process.setTerminationHandler { code, stderr in
                 if code == 0 {
-                    logger.info("Finished building! (Request ID: \(id.description, privacy: .public))")
+                    logger.debug("Finished building! (Request ID: \(id.description, privacy: .public))")
                     completion(nil)
                 } else {
                     if code == 8 {
-                        logger.info("Build (Request ID: \(id.description, privacy: .public)) was cancelled.")
+                        logger.debug("Build (Request ID: \(id.description, privacy: .public)) was cancelled.")
                         completion(ResponseError.cancelled)
                     } else {
                         logger.logFullObjectInMultipleLogMessages(

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -127,7 +127,7 @@ final class BazelTargetCompilerArgsExtractor {
             return []
         }
 
-        logger.info(
+        logger.debug(
             "Fetching SKOptions for \(platformInfo.label), strategy: \(strategy)",
         )
 
@@ -137,14 +137,14 @@ final class BazelTargetCompilerArgsExtractor {
             strategy: strategy
         )
 
-        logger.info("Fetching compiler args for \(cacheKey, privacy: .public)")
+        logger.debug("Fetching compiler args for \(cacheKey, privacy: .public)")
         if let cached = argsCache[cacheKey] {
             logger.debug("Returning cached results")
             return cached
         }
 
         // First, determine the SDK root based on the platform the target is built for.
-        let platformSdk = platformInfo.platformSdkName
+        let platformSdk = platformInfo.topLevelParentConfig.sdkName
         guard let sdkRoot: String = config.sdkRootPaths[platformSdk] else {
             throw BazelTargetCompilerArgsExtractorError.sdkRootNotFound(platformSdk)
         }
@@ -165,7 +165,7 @@ final class BazelTargetCompilerArgsExtractor {
             effectiveConfigName: platformInfo.topLevelParentConfig.effectiveConfigurationName
         )
 
-        logger.info("Finished processing compiler arguments")
+        logger.debug("Finished processing compiler arguments")
         logger.logFullObjectInMultipleLogMessages(
             level: .debug,
             header: "Parsed compiler arguments",

--- a/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/TargetSourcesHandler.swift
@@ -38,13 +38,13 @@ final class TargetSourcesHandler {
         _: RequestID
     ) throws -> BuildTargetSourcesResponse {
         let targets = request.targets
-        logger.info("Fetching sources for \(targets.count, privacy: .public) targets")
+        logger.debug("Fetching sources for \(targets.count, privacy: .public) targets")
 
         let srcs: [SourcesItem] = try targetStore.stateLock.withLockUnchecked {
             try targets.map { try targetStore.bazelTargetSrcs(forBSPURI: $0.uri) }
         }
 
-        logger.info(
+        logger.debug(
             "Returning \(srcs.count, privacy: .public) source specs"
         )
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFiles/WatchedFileChangeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/WatchedFiles/WatchedFileChangeHandler.swift
@@ -58,7 +58,7 @@ final class WatchedFileChangeHandler {
         }
 
         guard !changes.isEmpty else {
-            logger.info("No (supported) file changes to process.")
+            logger.debug("No (supported) file changes to process.")
             return
         }
 
@@ -75,11 +75,11 @@ final class WatchedFileChangeHandler {
 
             // If we received this notification before the build graph was calculated, we should stop.
             guard targetStore.isInitialized else {
-                logger.info("Received file changes before the build graph was calculated. Ignoring.")
+                logger.debug("Received file changes before the build graph was calculated. Ignoring.")
                 return []
             }
 
-            logger.info("Received \(changes.count, privacy: .public) file changes")
+            logger.debug("Received \(changes.count, privacy: .public) file changes")
 
             let deletedFiles = changes.filter { $0.type == .deleted }
             let createdFiles = changes.filter { $0.type == .created }

--- a/Sources/SourceKitBazelBSP/Server/MessageHandler/BSPMessageHandler.swift
+++ b/Sources/SourceKitBazelBSP/Server/MessageHandler/BSPMessageHandler.swift
@@ -60,7 +60,7 @@ final class BSPMessageHandler: MessageHandler {
     }
 
     func handle<Notification: NotificationType>(_ notification: Notification) {
-        logger.info("Received notification: \(Notification.method, privacy: .public)")
+        logger.debug("Received notification: \(Notification.method, privacy: .public)")
         do {
             let handler = try getHandler(for: notification, state: state)
             try handler(notification)
@@ -74,13 +74,13 @@ final class BSPMessageHandler: MessageHandler {
         id: RequestID,
         reply: @escaping (LSPResult<Request.Response>) -> Void
     ) {
-        logger.info("Received request: \(Request.method, privacy: .public)")
+        logger.debug("Received request: \(Request.method, privacy: .public)")
         do {
             let handler = try getHandler(for: request, id, reply, state: state)
             handler(request, id) { [buildLSPError] result in
                 do {
                     let response = try result.get()
-                    logger.info("Replying to \(Request.method, privacy: .public)")
+                    logger.debug("Replying to \(Request.method, privacy: .public)")
                     reply(.success(response))
                 } catch {
                     logger.error(

--- a/Sources/SourceKitBazelBSP/SharedUtils/Shell/ShellCommandRunner.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/Shell/ShellCommandRunner.swift
@@ -55,7 +55,7 @@ struct ShellCommandRunner: CommandRunner {
 
         runningProcess.attachPipes()
 
-        logger.info("Running shell: \(cmd, privacy: .public)")
+        logger.debug("Running shell: \(cmd, privacy: .public)")
         try process.run()
 
         return runningProcess

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -87,7 +87,6 @@ struct BazelTargetCompilerArgsExtractorTests {
             forTarget: BazelTargetPlatformInfo(
                 label: "//HelloWorld:HelloWorldLib",
                 topLevelParentLabel: "//HelloWorld:HelloWorld",
-                topLevelParentRuleType: .iosApplication,
                 topLevelParentConfig: helloWorldConfig
             ),
             withStrategy: .swiftModule,
@@ -103,7 +102,6 @@ struct BazelTargetCompilerArgsExtractorTests {
             forTarget: BazelTargetPlatformInfo(
                 label: "//HelloWorld:TodoObjCSupport",
                 topLevelParentLabel: "//HelloWorld:HelloWorld",
-                topLevelParentRuleType: .iosApplication,
                 topLevelParentConfig: helloWorldConfig
             ),
             withStrategy: .cImpl("HelloWorld/TodoObjCSupport/Sources/SKObjCUtils.m", "objective-c"),
@@ -120,7 +118,6 @@ struct BazelTargetCompilerArgsExtractorTests {
                 forTarget: BazelTargetPlatformInfo(
                     label: "//HelloWorld:TodoObjCSupport",
                     topLevelParentLabel: "//HelloWorld:HelloWorld",
-                    topLevelParentRuleType: .iosApplication,
                     topLevelParentConfig: helloWorldConfig
                 ),
                 withStrategy: .cImpl("HelloWorld/TodoObjCSupport/Sources/SomethingElse.m", "objective-c"),
@@ -140,7 +137,6 @@ struct BazelTargetCompilerArgsExtractorTests {
             forTarget: BazelTargetPlatformInfo(
                 label: "//HelloWorld:TodoObjCSupport",
                 topLevelParentLabel: "//HelloWorld:HelloWorld",
-                topLevelParentRuleType: .iosApplication,
                 topLevelParentConfig: helloWorldConfig
             ),
             withStrategy: .cHeader,
@@ -232,7 +228,6 @@ struct BazelTargetCompilerArgsExtractorTests {
                 forTarget: BazelTargetPlatformInfo(
                     label: "//HelloWorld:SomethingElseLib",
                     topLevelParentLabel: "//HelloWorld:HelloWorld",
-                    topLevelParentRuleType: .iosApplication,
                     topLevelParentConfig: helloWorldConfig
                 ),
                 withStrategy: .swiftModule,
@@ -253,7 +248,6 @@ struct BazelTargetCompilerArgsExtractorTests {
             forTarget: BazelTargetPlatformInfo(
                 label: "//HelloWorld:HelloWorldLib",
                 topLevelParentLabel: "//HelloWorld:HelloWorld",
-                topLevelParentRuleType: .iosApplication,
                 topLevelParentConfig: helloWorldConfig
             ),
             withStrategy: .swiftModule,

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -32,11 +32,12 @@ struct BazelTargetCompilerArgsExtractorTests {
     let helloWorldConfig: BazelTargetConfigurationInfo
 
     init() throws {
+        let configId: UInt32 = 1
         let aqueryResult = try BazelTargetQuerierParserImpl().processAquery(
             from: exampleAqueryOutput,
-            topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication)]
+            topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, configId)]
         )
-        self.helloWorldConfig = try #require(aqueryResult.topLevelLabelToConfigMap["//HelloWorld:HelloWorld"])
+        self.helloWorldConfig = try #require(aqueryResult.topLevelConfigIdToInfoMap[configId])
         self.aqueryResult = aqueryResult
     }
 

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -33,16 +33,15 @@ struct BazelTargetQuerierTests {
         bspURIsToBazelLabelsMap: [:],
         bspURIsToSrcsMap: [:],
         srcToBspURIsMap: [:],
-        topLevelLabelToRuleMap: [:],
         configurationToTopLevelLabelsMap: [:],
-        bazelLabelToParentConfigMap: [:]
+        bspUriToParentConfigMap: [:]
     )
 
     private static let emptyProcessedAqueryResult = ProcessedAqueryResult(
         targets: [:],
         actions: [:],
         configurations: [:],
-        topLevelLabelToConfigMap: [:]
+        topLevelConfigIdToInfoMap: [:]
     )
 
     private static func makeInitializedConfig(
@@ -288,7 +287,7 @@ struct BazelTargetQuerierTests {
         runnerMock.setResponse(for: expectedCommand, cwd: Self.mockRootUri, response: exampleAqueryOutput)
 
         _ = try querier.aquery(
-            topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication)],
+            topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, 1)],
             config: config,
             mnemonics: ["SwiftCompile"]
         )
@@ -312,8 +311,8 @@ struct BazelTargetQuerierTests {
 
         _ = try querier.aquery(
             topLevelTargets: [
-                ("//HelloWorld:HelloWorld", .iosApplication),
-                ("//Tests:Tests", .iosUnitTest),
+                ("//HelloWorld:HelloWorld", .iosApplication, 1),
+                ("//Tests:Tests", .iosUnitTest, 2),
             ],
             config: config,
             mnemonics: ["SwiftCompile", "ObjcCompile"]
@@ -347,7 +346,7 @@ struct BazelTargetQuerierTests {
 
         func run(mnemonics: [String]) throws {
             _ = try querier.aquery(
-                topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication)],
+                topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, 1)],
                 config: config,
                 mnemonics: mnemonics
             )

--- a/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetQuerierParserFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetQuerierParserFake.swift
@@ -43,7 +43,7 @@ final class BazelTargetQuerierParserFake: BazelTargetQuerierParser {
 
     func processAquery(
         from data: Data,
-        topLevelTargets: [(String, TopLevelRuleType)],
+        topLevelTargets: [(String, TopLevelRuleType, UInt32)],
     ) throws -> ProcessedAqueryResult {
         guard let mockAqueryResult else {
             unimplemented()


### PR DESCRIPTION
This PR lifts the restriction where a target cannot exist under multiple configurations. It will now process all variants.
There is still a restriction for multiple top-level apps though. Will fix that later on.

This also simplifies the sdk processing logic to now also enable device builds, as well as flipping a couple of log levels to make the logs less noisy.