### PR TITLE
Update BSP entrypoint to support async/await

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,16 +19,15 @@ let package = Package(
         .package(
             url:
             "https://github.com/swiftlang/swift-tools-protocols",
-            revision: "88612c51de4cbf636a6b948c64ea5ebd55b8a0ad"
+            .upToNextMinor(from: "0.0.10")
         ),
-
         .package(
             url: "https://github.com/apple/swift-argument-parser",
-            revision: "1.6.2"
+            .upToNextMajor(from: "1.6.2")
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",
-            revision: "1.33.3"
+            .upToNextMajor(from: "1.33.3")
         ),
     ],
     targets: [

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -24,7 +24,7 @@ import SourceKitBazelBSP
 
 private let logger = makeFileLevelBSPLogger()
 
-struct Serve: ParsableCommand {
+struct Serve: AsyncParsableCommand {
     @Option(help: "The name of the Bazel CLI to invoke (e.g. 'bazelisk')")
     var bazelWrapper: String = "bazel"
 
@@ -79,7 +79,7 @@ struct Serve: ParsableCommand {
     )
     var dependencyTargetToExclude: [String] = []
 
-    func run() throws {
+    func run() async throws {
         logger.info("`serve` invoked, initializing BSP server...")
 
         let topLevelRulesToDiscover: [TopLevelRuleType] =

--- a/Sources/sourcekit-bazel-bsp/SourcekitBazelBsp.swift
+++ b/Sources/sourcekit-bazel-bsp/SourcekitBazelBsp.swift
@@ -23,7 +23,7 @@ import SourceKitBazelBSP
 private let logger = makeFileLevelBSPLogger()
 
 @main
-struct SourcekitBazelBspCommand: ParsableCommand {
+struct SourcekitBazelBspCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A Build Server Protocol server for Bazel, for usage with SourceKit-LSP.",
         version: sourcekitBazelBSPVersion,
@@ -33,7 +33,7 @@ struct SourcekitBazelBspCommand: ParsableCommand {
 }
 
 extension SourcekitBazelBspCommand {
-    static func main() throws {
+    static func main() async throws {
         var command: ParsableCommand
         do {
             command = try parseAsRoot()
@@ -42,7 +42,11 @@ extension SourcekitBazelBspCommand {
             exit(withError: error)
         }
         do {
-            try command.run()
+            if var asyncCommand = command as? AsyncParsableCommand {
+                try await asyncCommand.run()
+            } else {
+                try command.run()
+            }
         } catch {
             logger.fault("Failed to initialize the BSP: \(error, privacy: .public)")
             exit(withError: error)


### PR DESCRIPTION
Will allow us to use async/await apis like https://github.com/swiftlang/swift-subprocess in the future which im planning to migrate us to