### PR TITLE
Make launchType null for extensions/watchOS

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
@@ -29,7 +29,7 @@ struct BazelTargetGraphReport: Codable, Equatable {
             case test
         }
         let label: String
-        let launchType: LaunchType
+        let launchType: LaunchType?
         let configId: UInt32
     }
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -260,10 +260,19 @@ extension BazelTargetStoreImpl {
         let topLevelTargets = cqueryResult?.topLevelTargets ?? []
         for (label, ruleType, configId) in topLevelTargets {
             let topLevelConfig = try topLevelConfigInfo(forConfig: configId)
+            let launchType: BazelTargetGraphReport.TopLevelTarget.LaunchType? = {
+                if ruleType.testBundleRule != nil {
+                    return .test
+                } else if ruleType.isLaunchableApp {
+                    return .app
+                } else {
+                    return nil
+                }
+            }()
             reportTopLevel.append(
                 .init(
                     label: label,
-                    launchType: ruleType.testBundleRule != nil ? .test : .app,
+                    launchType: launchType,
                     configId: configId
                 )
             )

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
@@ -99,4 +99,15 @@ public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument, Senda
         default: return false
         }
     }
+
+    /// Whether or not this is an app rule that supports `bazel run`.
+    /// Standalone watchOS apps are not executable as of writing.
+    var isLaunchableApp: Bool {
+        switch self {
+        case .iosApplication, .iosAppClip, .macosApplication, .macosCommandLineApplication, .tvosApplication,
+            .visionosApplication:
+            return true
+        default: return false
+        }
+    }
 }


### PR DESCRIPTION
It turns out that watchOS apps are not executable, so for now I'm marking those as null to not affect the upcoming extension.