### PR TITLE
Add information on test files to the graph report

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
@@ -31,6 +31,7 @@ struct BazelTargetGraphReport: Codable, Equatable {
         let label: String
         let launchType: LaunchType?
         let configId: UInt32
+        let testSources: [String]?
     }
 
     struct DependencyTarget: Codable, Equatable {

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -269,11 +269,16 @@ extension BazelTargetStoreImpl {
                     return nil
                 }
             }()
+            let testSources: [String]? = {
+                guard launchType == .test else { return nil }
+                return cqueryResult?.bazelLabelToTestFilesMap[label]?.map { $0.stringValue }
+            }()
             reportTopLevel.append(
                 .init(
                     label: label,
                     launchType: launchType,
-                    configId: configId
+                    configId: configId,
+                    testSources: testSources
                 )
             )
             reportConfigurations[configId] = .init(

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedCqueryResult.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedCqueryResult.swift
@@ -31,4 +31,5 @@ struct ProcessedCqueryResult {
     let srcToBspURIsMap: [URI: [URI]]
     let configurationToTopLevelLabelsMap: [UInt32: [String]]
     let bspUriToParentConfigMap: [URI: UInt32]
+    let bazelLabelToTestFilesMap: [String: [URI]]
 }

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -34,7 +34,8 @@ struct BazelTargetQuerierTests {
         bspURIsToSrcsMap: [:],
         srcToBspURIsMap: [:],
         configurationToTopLevelLabelsMap: [:],
-        bspUriToParentConfigMap: [:]
+        bspUriToParentConfigMap: [:],
+        bazelLabelToTestFilesMap: [:]
     )
 
     private static let emptyProcessedAqueryResult = ProcessedAqueryResult(


### PR DESCRIPTION
Exposes information on files imported by test bundles, to be used by IDE integrations.