### PR TITLE
fix: setup rule ensure we do not modify lsp/bsp files unless changed

### DIFF
--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+# Returns 0 (true) if target doesn't exist or differs from source
+function needs_update() {
+    local source="$1"
+    local target="$2"
+    ! [ -f "$target" ] || ! cmp -s "$source" "$target"
+}
+
 sourcekit_bazel_bsp_path="%sourcekit_bazel_bsp_path%"
 bsp_config_path="%bsp_config_path%"
 lsp_config_path="%lsp_config_path%"
@@ -16,23 +23,31 @@ target_bsp_config_path="$bsp_folder_path/skbsp.json"
 target_sourcekit_bazel_bsp_path="$bsp_folder_path/sourcekit-bazel-bsp"
 target_lsp_config_path="$lsp_folder_path/config.json"
 
-cp "$bsp_config_path" "$target_bsp_config_path"
-
-# If files are identical, do nothing
-if [ -f "$target_lsp_config_path" ] && cmp -s "$lsp_config_path" "$target_lsp_config_path"; then
-    :
-# Merge LSP config if jq is available and existing config exists
-elif [ -f "$target_lsp_config_path" ] && command -v jq &> /dev/null; then
-    jq -S -s '.[0] * .[1]' "$target_lsp_config_path" "$lsp_config_path" > "$target_lsp_config_path.tmp"
-    mv "$target_lsp_config_path.tmp" "$target_lsp_config_path"
-else
-    cp "$lsp_config_path" "$target_lsp_config_path"
+# Update the BSP config if needed
+if needs_update "$bsp_config_path" "$target_bsp_config_path"; then
+    cp "$bsp_config_path" "$target_bsp_config_path"
+    chmod +w "$target_bsp_config_path"
 fi
 
-# Delete the existing binary first to avoid issues when running this while a server is running.
-rm -f "$target_sourcekit_bazel_bsp_path" || true
-cp "$sourcekit_bazel_bsp_path" "$target_sourcekit_bazel_bsp_path"
+# Update the LSP config if needed
+# For merging, we need to compare the merged result (not the source template)
+if [ -f "$target_lsp_config_path" ] && command -v jq &> /dev/null; then
+    jq -S -s '.[0] * .[1]' "$target_lsp_config_path" "$lsp_config_path" > "$target_lsp_config_path.tmp"
+    if ! cmp -s "$target_lsp_config_path.tmp" "$target_lsp_config_path"; then
+        mv "$target_lsp_config_path.tmp" "$target_lsp_config_path"
+        chmod +w "$target_lsp_config_path"
+    else
+        rm -f "$target_lsp_config_path.tmp"
+    fi
+elif needs_update "$lsp_config_path" "$target_lsp_config_path"; then
+    cp "$lsp_config_path" "$target_lsp_config_path"
+    chmod +w "$target_lsp_config_path"
+fi
 
-chmod +w "$target_bsp_config_path"
-chmod +w "$target_sourcekit_bazel_bsp_path"
-chmod +w "$target_lsp_config_path"
+# Update the BSP binary if needed
+# Delete the existing binary first to avoid issues when running this while a server is running.
+if needs_update "$sourcekit_bazel_bsp_path" "$target_sourcekit_bazel_bsp_path"; then
+    rm -f "$target_sourcekit_bazel_bsp_path" || true
+    cp "$sourcekit_bazel_bsp_path" "$target_sourcekit_bazel_bsp_path"
+    chmod +w "$target_sourcekit_bazel_bsp_path"
+fi


### PR DESCRIPTION
I was seeing the LSP require a restart still even after https://github.com/spotify/sourcekit-bazel-bsp/pull/138. We werent comparing the merged lsp config correct and thus recreating it all the time.

With these changes I no longer see LSP restart notifications when the i rerun the setup target.

Changes:

- Dont modify files at all unless they have changed using `needs_update`
- Compare the merged lsp config to the actual to fix LSP restarts
- Refactor a lil to group the commands on the file it relates to