### PR TITLE
Add parameter for fully overriding the LSP config

### DIFF
--- a/Example/HelloWorld/BUILD
+++ b/Example/HelloWorld/BUILD
@@ -269,4 +269,5 @@ setup_sourcekit_bsp(
     targets = [
         "//HelloWorld/...",
     ],
+    merge_lsp_config = True,
 )

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -63,6 +63,8 @@ def _setup_sourcekit_bsp_impl(ctx):
         lsp_config_json["buildSettingsTimeout"] = ctx.attr.lsp_timeout
     ctx.actions.write(rendered_lsp_config, json.encode_indent(lsp_config_json, indent = "  "))
 
+    merge_lsp_config_env = "1" if ctx.attr.merge_lsp_config else ""
+
     # Generating the script that ties everything together
     executable = ctx.actions.declare_file("setup_sourcekit_bsp.sh")
     ctx.actions.expand_template(
@@ -73,6 +75,7 @@ def _setup_sourcekit_bsp_impl(ctx):
             "%bsp_config_path%": rendered_bsp_config.short_path,
             "%lsp_config_path%": rendered_lsp_config.short_path,
             "%sourcekit_bazel_bsp_path%": ctx.executable.sourcekit_bazel_bsp.short_path,
+            "%merge_lsp_config_env%": merge_lsp_config_env,
         },
     )
     tools_runfiles = ctx.runfiles(
@@ -158,6 +161,10 @@ setup_sourcekit_bsp = rule(
         "apple_support_repo_name": attr.string(
             doc = "The name of the apple_support external repository in your workspace. Change this if using a different name.",
             default = "apple_support",
+        ),
+        "merge_lsp_config": attr.bool(
+            doc = "If set to true, the generated .sourcekit-lsp/config.json will merge with any existing contents instead of fully overriding the file.",
+            default = True,
         ),
     },
 )

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -15,6 +15,7 @@ lsp_config_path="%lsp_config_path%"
 
 bsp_folder_path="$BUILD_WORKSPACE_DIRECTORY/.bsp"
 lsp_folder_path="$BUILD_WORKSPACE_DIRECTORY/.sourcekit-lsp"
+should_merge_lsp_config="%merge_lsp_config_env%"
 
 mkdir -p "$bsp_folder_path"
 mkdir -p "$lsp_folder_path"
@@ -32,7 +33,11 @@ fi
 # Update the LSP config if needed
 # For merging, we need to compare the merged result (not the source template)
 if [ -f "$target_lsp_config_path" ] && command -v jq &> /dev/null; then
-    jq -S -s '.[0] * .[1]' "$target_lsp_config_path" "$lsp_config_path" > "$target_lsp_config_path.tmp"
+    if [ "$should_merge_lsp_config" = "1" ]; then
+        jq -S -s '.[0] * .[1]' "$target_lsp_config_path" "$lsp_config_path" > "$target_lsp_config_path.tmp"
+    else
+        cp "$lsp_config_path" "$target_lsp_config_path.tmp"
+    fi
     if ! cmp -s "$target_lsp_config_path.tmp" "$target_lsp_config_path"; then
         mv "$target_lsp_config_path.tmp" "$target_lsp_config_path"
         chmod +w "$target_lsp_config_path"


### PR DESCRIPTION
Adds a mechanism to fix the issue mentioned in https://github.com/spotify/sourcekit-bazel-bsp/pull/159 where nullable configs would be impossible to remove with the current setup.

```
  "index": {
    "indexPrefixMap": {
      "./bazel-out": "/private/var/tmp/_bazel_rochab/1770f703eb26386ff7ba3a09ebdb2631-sourcekit-bazel-bsp/execroot/_main/bazel-out",
      "./external": "/private/var/tmp/_bazel_rochab/1770f703eb26386ff7ba3a09ebdb2631-sourcekit-bazel-bsp/execroot/_main/external"
    }
  },
  ```