### PR TITLE
Allow aqueries to be customized

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,17 +1,32 @@
 {
+  "model": "claude-opus-4-5",
   "permissions": {
     "allow": [
-      "Bash(find:*)",
       "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
       "Bash(rgrep:*)",
       "Bash(cat:*)",
+      "Bash(ls:*)",
+      "Bash(cd:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(pwd:*)",
       "Bash(swift build:*)",
       "Bash(swift test:*)",
+      "Bash(swift format:*)",
       "Bash(git show:*)",
       "Bash(git log:*)",
       "Bash(git diff:*)",
       "Bash(git status:*)",
-      "Bash(swift format:*)"
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr status:*)",
+      "Bash(gh pr view:*)",
+      "Bash(bazelisk build:*)",
+      "Bash(bazelisk test:*)",
+      "Bash(bazelisk query:*)",
+      "Bash(bazelisk cquery:*)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ sourcekit-bazel-bsp is a Build Server Protocol (BSP) implementation that bridges
 
 The project itself is built using Swift Package Manager. There is also a `Example/` folder containing a Bazel iOS application demonstrating the tool's functionality, as well as a `vscode-extension/` containing a helper VSCode/Cursor extension that acts as a companion to the main BSP code.
 
+When adding new CLI flags to Serve.swift, you should also add them to the `rules/setup_sourcekit_bsp.bzl` Bazel equivalent if applicable.
+
 ## Common Commands
 
 ### Base instructions

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -168,12 +168,12 @@ final class BazelTargetQuerier {
         let mnemonicsFilter = mnemonics.joined(separator: "|")
         let depsQuery = Self.queryDepsString(forTargets: targets)
 
-        let otherFlags =
+        let baseFlags =
             [
                 "--noinclude_artifacts",
                 "--noinclude_aspects",
-                "--features=-compiler_param_file",  // Context: https://github.com/spotify/sourcekit-bazel-bsp/pull/60
-            ].joined(separator: " ") + " --output proto"
+            ] + config.baseConfig.aqueryFlags
+        let otherFlags = baseFlags.joined(separator: " ") + " --output proto"
         let cmd = "aquery \"mnemonic('\(mnemonicsFilter)', \(depsQuery))\" \(otherFlags)"
 
         logger.info("Processing aquery request...")

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -28,6 +28,7 @@ package struct BaseServerConfig: Equatable {
     let bazelWrapper: String
     let targets: [String]
     let indexFlags: [String]
+    let aqueryFlags: [String]
     let filesToWatch: String?
     let compileTopLevel: Bool
     let topLevelRulesToDiscover: [TopLevelRuleType]
@@ -40,6 +41,7 @@ package struct BaseServerConfig: Equatable {
         bazelWrapper: String,
         targets: [String],
         indexFlags: [String],
+        aqueryFlags: [String] = [],
         filesToWatch: String?,
         compileTopLevel: Bool,
         topLevelRulesToDiscover: [TopLevelRuleType] = TopLevelRuleType.allCases,
@@ -51,6 +53,7 @@ package struct BaseServerConfig: Equatable {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
         self.indexFlags = indexFlags
+        self.aqueryFlags = aqueryFlags
         self.filesToWatch = filesToWatch
         self.compileTopLevel = compileTopLevel
         self.topLevelRulesToDiscover = topLevelRulesToDiscover

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -42,6 +42,13 @@ struct Serve: AsyncParsableCommand {
     )
     var indexFlag: [String] = []
 
+    @Option(
+        parsing: .singleValue,
+        help:
+            "A flag that should be passed to all aquery invocations used to gather compiler arguments. Do not include the -- prefix. Can be specified multiple times."
+    )
+    var aqueryFlag: [String] = []
+
     @Option(help: "Comma separated list of file globs to watch for changes.")
     var filesToWatch: String?
 
@@ -93,12 +100,14 @@ struct Serve: AsyncParsableCommand {
         let dependencyRulesToDiscover: [DependencyRuleType] =
             dependencyRuleToDiscover.isEmpty ? DependencyRuleType.allCases : dependencyRuleToDiscover
         let indexFlags = indexFlag.map { "--" + $0 }
+        let aqueryFlags = aqueryFlag.map { "--" + $0 }
         let targets = target.isEmpty ? ["//..."] : target
 
         let config = BaseServerConfig(
             bazelWrapper: bazelWrapper,
             targets: targets,
             indexFlags: indexFlags,
+            aqueryFlags: aqueryFlags,
             filesToWatch: filesToWatch,
             compileTopLevel: compileTopLevel,
             topLevelRulesToDiscover: topLevelRulesToDiscover,

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -20,6 +20,9 @@ def _setup_sourcekit_bsp_impl(ctx):
     for index_flag in ctx.attr.index_flags:
         bsp_config_argv.append("--index-flag")
         bsp_config_argv.append(index_flag)
+    for aquery_flag in ctx.attr.aquery_flags:
+        bsp_config_argv.append("--aquery-flag")
+        bsp_config_argv.append(aquery_flag)
     for top_level_rule in ctx.attr.top_level_rules_to_discover:
         bsp_config_argv.append("--top-level-rule-to-discover")
         bsp_config_argv.append(top_level_rule)
@@ -132,6 +135,10 @@ setup_sourcekit_bsp = rule(
         ),
         "index_flags": attr.string_list(
             doc = "Flags that should be passed to all indexing-related Bazel invocations. Do not include the -- prefix.",
+            default = [],
+        ),
+        "aquery_flags": attr.string_list(
+            doc = "Flags that should be passed to all aquery invocations used to gather compiler arguments. Do not include the -- prefix.",
             default = [],
         ),
         "files_to_watch": attr.string_list(


### PR DESCRIPTION
Instead of passing `--features=-compiler_param_file` ourselves, users can now specify `--aquery-flag` to pass this and any other bits they require. This improves the performance of this command for projects that don't require this.