### PR TITLE
Base targets around checksums instead of configIds

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
@@ -30,17 +30,17 @@ struct BazelTargetGraphReport: Codable, Equatable {
         }
         let label: String
         let launchType: LaunchType?
-        let configId: UInt32
+        let configChecksum: String
         let testSources: [String]?
     }
 
     struct DependencyTarget: Codable, Equatable {
         let label: String
-        let configId: UInt32
+        let configChecksum: String
     }
 
     struct Configuration: Codable, Equatable {
-        let id: UInt32
+        let checksum: String
         let platform: String
         let minimumOsVersion: String
         let cpuArch: String

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetPlatformInfo.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetPlatformInfo.swift
@@ -35,6 +35,10 @@ struct BazelTargetConfigurationInfo: Hashable {
     /// e.g. darwin_arm64-dbg-macos-arm64-min15.0-applebin_macos-ST-d1334902beb6
     let configurationName: String
 
+    /// The configuration checksum as stated in the aquery,
+    /// e.g. d1334902beb6
+    let configurationChecksum: String
+
     /// The configuration name that should actually apply when compiling a library.
     /// Only relevant when not passing --compile-top-level.
     /// e.g. darwin_arm64-dbg-macos-arm64-min15.0

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerier.swift
@@ -155,7 +155,7 @@ final class BazelTargetQuerier {
 
     /// Runs an aquery across the codebase over a list of specific target dependencies.
     func aquery(
-        topLevelTargets: [(String, TopLevelRuleType, UInt32)],
+        topLevelTargets: [(String, TopLevelRuleType, String)],
         config: InitializedServerConfig,
         mnemonics: [String]
     ) throws -> ProcessedAqueryResult {

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedAqueryResult.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedAqueryResult.swift
@@ -28,5 +28,5 @@ struct ProcessedAqueryResult: Hashable {
     let targets: [String: Analysis_Target]
     let actions: [UInt32: [Analysis_Action]]
     let configurations: [UInt32: Analysis_Configuration]
-    let topLevelConfigIdToInfoMap: [UInt32: BazelTargetConfigurationInfo]
+    let topLevelConfigChecksumToInfoMap: [String: BazelTargetConfigurationInfo]
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedCqueryResult.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedCqueryResult.swift
@@ -25,11 +25,11 @@ private let logger = makeFileLevelBSPLogger()
 
 struct ProcessedCqueryResult {
     let buildTargets: [BuildTarget]
-    let topLevelTargets: [(String, TopLevelRuleType, UInt32)]
+    let topLevelTargets: [(String, TopLevelRuleType, String)]
     let bspURIsToBazelLabelsMap: [URI: String]
     let bspURIsToSrcsMap: [URI: SourcesItem]
     let srcToBspURIsMap: [URI: [URI]]
-    let configurationToTopLevelLabelsMap: [UInt32: [String]]
-    let bspUriToParentConfigMap: [URI: UInt32]
+    let configurationToTopLevelLabelsMap: [String: [String]]
+    let bspUriToParentConfigMap: [URI: String]
     let bazelLabelToTestFilesMap: [String: [URI]]
 }

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -32,12 +32,12 @@ struct BazelTargetCompilerArgsExtractorTests {
     let helloWorldConfig: BazelTargetConfigurationInfo
 
     init() throws {
-        let configId: UInt32 = 1
+        let configChecksum = "67b25b5da4a32f875d5441b55c9c8e798ebd3f2a13dd405eddf72e85c573b670"
         let aqueryResult = try BazelTargetQuerierParserImpl().processAquery(
             from: exampleAqueryOutput,
-            topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, configId)]
+            topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, configChecksum)]
         )
-        self.helloWorldConfig = try #require(aqueryResult.topLevelConfigIdToInfoMap[configId])
+        self.helloWorldConfig = try #require(aqueryResult.topLevelConfigChecksumToInfoMap[configChecksum])
         self.aqueryResult = aqueryResult
     }
 

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
@@ -296,16 +296,22 @@ struct BazelTargetQuerierParserImplTests {
         let parser = BazelTargetQuerierParserImpl()
 
         // These details are meant to match the provided aquery pb example.
-        // Config IDs: 1 = iOS, 2 = macOS, 3 = watchOS
-        let topLevelTargets: [(String, TopLevelRuleType, UInt32)] = [
-            ("//HelloWorld:HelloWorld", .iosApplication, 1),
-            ("//HelloWorld:HelloWorldMacApp", .macosApplication, 2),
-            ("//HelloWorld:HelloWorldMacCLIApp", .macosCommandLineApplication, 2),
-            ("//HelloWorld:HelloWorldMacTests", .macosUnitTest, 2),
-            ("//HelloWorld:HelloWorldTests", .iosUnitTest, 1),
-            ("//HelloWorld:HelloWorldWatchApp", .watchosApplication, 3),
-            ("//HelloWorld:HelloWorldWatchExtension", .watchosExtension, 3),
-            ("//HelloWorld:HelloWorldWatchTests", .watchosUnitTest, 3),
+        // Config checksums (full SHA-256 hashes from aquery protobuf):
+        // iOS = 67b25b5da4a32f875d5441b55c9c8e798ebd3f2a13dd405eddf72e85c573b670
+        // macOS = e82cc70c288f80852360009cb9e73108d19085934aa23d230eaa28369b761419
+        // watchOS = e465f55b6b90678c4b05125ebcc8070d7c4d9e0e843912380861d3c1bfe9c1da
+        let iosChecksum = "67b25b5da4a32f875d5441b55c9c8e798ebd3f2a13dd405eddf72e85c573b670"
+        let macOsChecksum = "e82cc70c288f80852360009cb9e73108d19085934aa23d230eaa28369b761419"
+        let watchOsChecksum = "e465f55b6b90678c4b05125ebcc8070d7c4d9e0e843912380861d3c1bfe9c1da"
+        let topLevelTargets: [(String, TopLevelRuleType, String)] = [
+            ("//HelloWorld:HelloWorld", .iosApplication, iosChecksum),
+            ("//HelloWorld:HelloWorldMacApp", .macosApplication, macOsChecksum),
+            ("//HelloWorld:HelloWorldMacCLIApp", .macosCommandLineApplication, macOsChecksum),
+            ("//HelloWorld:HelloWorldMacTests", .macosUnitTest, macOsChecksum),
+            ("//HelloWorld:HelloWorldTests", .iosUnitTest, iosChecksum),
+            ("//HelloWorld:HelloWorldWatchApp", .watchosApplication, watchOsChecksum),
+            ("//HelloWorld:HelloWorldWatchExtension", .watchosExtension, watchOsChecksum),
+            ("//HelloWorld:HelloWorldWatchTests", .watchosUnitTest, watchOsChecksum),
         ]
 
         let result = try parser.processAquery(
@@ -313,14 +319,15 @@ struct BazelTargetQuerierParserImplTests {
             topLevelTargets: topLevelTargets
         )
 
-        // 3 unique config IDs (iOS, macOS, watchOS)
-        #expect(result.topLevelConfigIdToInfoMap.count == 3)
+        // 3 unique config checksums (iOS, macOS, watchOS)
+        #expect(result.topLevelConfigChecksumToInfoMap.count == 3)
 
-        // iOS config (config ID 1)
+        // iOS config
         #expect(
-            result.topLevelConfigIdToInfoMap[1]
+            result.topLevelConfigChecksumToInfoMap[iosChecksum]
                 == BazelTargetConfigurationInfo(
                     configurationName: "ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300",
+                    configurationChecksum: iosChecksum,
                     effectiveConfigurationName: "ios_sim_arm64-dbg-ios-sim_arm64-min17.0",
                     minimumOsVersion: "17.0",
                     platform: "ios",
@@ -329,11 +336,12 @@ struct BazelTargetQuerierParserImplTests {
                 )
         )
 
-        // macOS config (config ID 2)
+        // macOS config
         #expect(
-            result.topLevelConfigIdToInfoMap[2]
+            result.topLevelConfigChecksumToInfoMap[macOsChecksum]
                 == BazelTargetConfigurationInfo(
                     configurationName: "darwin_arm64-dbg-macos-arm64-min15.0-ST-3b9f41d61db6",
+                    configurationChecksum: macOsChecksum,
                     effectiveConfigurationName: "darwin_arm64-dbg-macos-arm64-min15.0",
                     minimumOsVersion: "15.0",
                     platform: "darwin",
@@ -342,11 +350,12 @@ struct BazelTargetQuerierParserImplTests {
                 )
         )
 
-        // watchOS config (config ID 3)
+        // watchOS config
         #expect(
-            result.topLevelConfigIdToInfoMap[3]
+            result.topLevelConfigChecksumToInfoMap[watchOsChecksum]
                 == BazelTargetConfigurationInfo(
                     configurationName: "watchos_arm64-dbg-watchos-arm64-min7.0-ST-f4f2bb7e56ed",
+                    configurationChecksum: watchOsChecksum,
                     effectiveConfigurationName: "watchos_arm64-dbg-watchos-arm64-min7.0",
                     minimumOsVersion: "7.0",
                     platform: "watchos",

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -42,7 +42,7 @@ struct BazelTargetQuerierTests {
         targets: [:],
         actions: [:],
         configurations: [:],
-        topLevelConfigIdToInfoMap: [:]
+        topLevelConfigChecksumToInfoMap: [:]
     )
 
     private static func makeInitializedConfig(
@@ -290,7 +290,7 @@ struct BazelTargetQuerierTests {
         runnerMock.setResponse(for: expectedCommand, cwd: Self.mockRootUri, response: exampleAqueryOutput)
 
         _ = try querier.aquery(
-            topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, 1)],
+            topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, "abc123")],
             config: config,
             mnemonics: ["SwiftCompile"]
         )
@@ -314,8 +314,8 @@ struct BazelTargetQuerierTests {
 
         _ = try querier.aquery(
             topLevelTargets: [
-                ("//HelloWorld:HelloWorld", .iosApplication, 1),
-                ("//Tests:Tests", .iosUnitTest, 2),
+                ("//HelloWorld:HelloWorld", .iosApplication, "abc123"),
+                ("//Tests:Tests", .iosUnitTest, "def456"),
             ],
             config: config,
             mnemonics: ["SwiftCompile", "ObjcCompile"]
@@ -349,7 +349,7 @@ struct BazelTargetQuerierTests {
 
         func run(mnemonics: [String]) throws {
             _ = try querier.aquery(
-                topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, 1)],
+                topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, "abc123")],
                 config: config,
                 mnemonics: mnemonics
             )
@@ -385,7 +385,7 @@ struct BazelTargetQuerierTests {
         runnerMock.setResponse(for: expectedCommand, cwd: Self.mockRootUri, response: exampleAqueryOutput)
 
         _ = try querier.aquery(
-            topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, 1)],
+            topLevelTargets: [("//HelloWorld:HelloWorld", .iosApplication, "abc123")],
             config: config,
             mnemonics: ["SwiftCompile"]
         )

--- a/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetQuerierParserFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetQuerierParserFake.swift
@@ -43,7 +43,7 @@ final class BazelTargetQuerierParserFake: BazelTargetQuerierParser {
 
     func processAquery(
         from data: Data,
-        topLevelTargets: [(String, TopLevelRuleType, UInt32)],
+        topLevelTargets: [(String, TopLevelRuleType, String)],
     ) throws -> ProcessedAqueryResult {
         guard let mockAqueryResult else {
             unimplemented()


### PR DESCRIPTION
Instead of storing configIds like 1,2,3, store the config's checksum instead. This makes it possible to connect data across different requests as well as making issues slightly easier to debug.