### PR TITLE
Add retry logic to InitializeHandler

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -32,7 +32,6 @@ enum BazelTargetQuerierParserError: Error, LocalizedError {
     case multipleParentActions(String)
     case configurationNotFound(UInt32)
     case sdkNameNotFound(String)
-    case indexOutOfBounds(Int, Int)
     case unexpectedLanguageRule(String, String)
     case unexpectedTargetType(Int)
     case noTopLevelTargets([TopLevelRuleType])
@@ -54,8 +53,6 @@ enum BazelTargetQuerierParserError: Error, LocalizedError {
             return "Configuration \(id) not found in the aquery output."
         case .sdkNameNotFound(let cpuAndArch):
             return "SDK info could not be inferred for \(cpuAndArch)."
-        case .indexOutOfBounds(let index, let line):
-            return "Index \(index) is out of bounds for array at line \(line)"
         case .unexpectedLanguageRule(let target, let ruleClass):
             return "Could not determine \(target)'s language: Unexpected rule \(ruleClass)"
         case .unexpectedTargetType(let type): return "Parsed unexpected target type: \(type)"
@@ -636,17 +633,6 @@ extension BazelTargetQuerierParserImpl {
             }
         }
         throw BazelTargetQuerierParserError.sdkNameNotFound(cpuAndArch)
-    }
-}
-
-// MARK: - Bazel label parsing helpers
-
-extension Array {
-    fileprivate func getIndexThrowing(_ index: Int, _ line: Int = #line) throws -> Element {
-        guard index < count else {
-            throw BazelTargetQuerierParserError.indexOutOfBounds(index, line)
-        }
-        return self[index]
     }
 }
 

--- a/Sources/SourceKitBazelBSP/SharedUtils/Retry.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/Retry.swift
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+/// Executes a throwing operation with retry logic.
+/// - Parameters:
+///   - maxAttempts: Maximum number of attempts before giving up. Defaults to 3.
+///   - onRetry: Optional callback invoked after each failed attempt with the attempt number and error.
+///   - operation: The throwing operation to execute.
+///   - delay: Optional delay between attempts. Defaults to nil.
+/// - Returns: The result of the operation if successful.
+/// - Throws: The last error if all attempts fail.
+package func withRetry<T>(
+    maxAttempts: Int = 3,
+    onRetry: ((Int, Error) -> Void)? = nil,
+    operation: () throws -> T,
+    delay: TimeInterval? = nil
+) throws -> T {
+    for attempt in 1...maxAttempts {
+        do {
+            return try operation()
+        } catch {
+            onRetry?(attempt, error)
+            if let delay = delay {
+                Thread.sleep(forTimeInterval: delay)
+            }
+            if attempt == maxAttempts {
+                throw error
+            }
+        }
+    }
+    fatalError("Unreachable")
+}

--- a/Sources/SourceKitBazelBSP/SharedUtils/SafeIndex.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/SafeIndex.swift
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+enum SafeIndexError: Error, LocalizedError {
+    case indexOutOfBounds(Int, Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .indexOutOfBounds(let index, let line): return "Index \(index) is out of bounds for array at line \(line)"
+        }
+    }
+}
+
+extension Array {
+    func getIndexThrowing(_ index: Int, _ line: Int = #line) throws -> Element {
+        guard index < count else {
+            throw SafeIndexError.indexOutOfBounds(index, line)
+        }
+        return self[index]
+    }
+}


### PR DESCRIPTION
If the Bazel commands in the initialize logic crash, we should try again a couple of times before returning a full error. This allows the BSP to recover in the event of random issues like Bazel server crashes.