### PR TITLE
Add aspect-based builds for library indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This approach provides several benefits:
 2. **Correct platform configuration**: Libraries automatically inherit the correct platform transitions from their parent app.
 3. **Incremental efficiency**: Only the requested library outputs are produced, even though the build is routed through the parent.
 
-The aspect is automatically generated in `.bsp/skbsp_generated/aspect.bzl` when you run the setup command. Top-level targets (apps, extensions, tests) are always built directly without the aspect.
+The aspect is automatically generated in `.bsp/skbsp_generated/aspect.bzl` when you run the setup command.
 
 ## Bazel Caching Implications
 

--- a/README.md
+++ b/README.md
@@ -90,11 +90,32 @@ The setup instructions for other IDEs (and by extension, Claude Code) will depen
     - The BSP's many filtering arguments can be particularly useful for more complex cases.
     - For smaller apps, this doesn't make much difference and it should be fine to import the entire app.
 
+## How Library Builds Work
+
+When sourcekit-lsp requests building a specific library for indexing, the BSP needs to compile it with the correct platform configuration (iOS, tvOS, etc.). The BSP uses a **Bazel aspect** to build libraries through their parent application:
+
+```
+bazel build //App:MyApp --aspects=//.bsp/skbsp_generated:aspect.bzl%platform_deps_aspect --output_groups=aspect_path_to_MyLibrary
+```
+
+This approach provides several benefits:
+
+1. **Cache consistency**: Library builds share the same action cache keys as full app builds, meaning no duplicate compilation work.
+2. **Correct platform configuration**: Libraries automatically inherit the correct platform transitions from their parent app.
+3. **Incremental efficiency**: Only the requested library outputs are produced, even though the build is routed through the parent.
+
+The aspect is automatically generated in `.bsp/skbsp_generated/aspect.bzl` when you run the setup command. Top-level targets (apps, extensions, tests) are always built directly without the aspect.
+
 ## Bazel Caching Implications
 
-The BSP by default works by attempting to build your library targets individually with a set of platform flags based on the library's parent app, which is an action that currently does not share action cache keys with the compilation of the apps themselves. If your goal is to have index builds share cache with regular app builds, this would mean that as of writing you would end up with two sets of artifacts.
+If you encounter issues with the aspect-based approach, you can pass the `--compile-top-level` flag to make the BSP compile the target's **parent** instead of using aspects. We recommend using this for projects that define fine-grained `*_build_test` targets and providing them as top-level targets for the BSP, as those don't suffer from this issue and thus enables maximum predictability and cacheability.
 
-If this is undesirable, you can pass the `--compile-top-level` flag to make the BSP compile the target's **parent** instead, without any special flags. We recommend using this for projects that define fine-grained `*_build_test` targets and providing them as top-level targets for the BSP, as those don't suffer from this issue and thus enables maximum predictability and cacheability.
+```python
+setup_sourcekit_bsp(
+    # ...
+    compile_top_level = True,
+)
+```
 
 ## Troubleshooting
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
@@ -49,10 +49,6 @@ struct BazelTargetGraphReport: Codable, Equatable {
         /// Build invocation template for building dependencies using the aspect approach.
         /// Format: "build {parent} --aspects=... --output_groups={OUTPUT_GROUP}"
         let buildInvocation: String
-        /// Deprecated: Legacy build args for direct library builds.
-        /// Kept for backward compatibility with older VSCode extensions.
-        /// New code should use buildInvocation with the aspect approach.
-        let dependencyBuildArgs: [String]?
     }
 
     let topLevelTargets: [TopLevelTarget]

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
@@ -37,6 +37,7 @@ struct BazelTargetGraphReport: Codable, Equatable {
     struct DependencyTarget: Codable, Equatable {
         let label: String
         let configMnemonic: String
+        let topLevelParent: String
     }
 
     struct Configuration: Codable, Equatable {
@@ -45,7 +46,13 @@ struct BazelTargetGraphReport: Codable, Equatable {
         let minimumOsVersion: String
         let cpuArch: String
         let sdkName: String
-        let dependencyBuildArgs: [String]
+        /// Build invocation template for building dependencies using the aspect approach.
+        /// Format: "build {parent} --aspects=... --output_groups={OUTPUT_GROUP}"
+        let buildInvocation: String
+        /// Deprecated: Legacy build args for direct library builds.
+        /// Kept for backward compatibility with older VSCode extensions.
+        /// New code should use buildInvocation with the aspect approach.
+        let dependencyBuildArgs: [String]?
     }
 
     let topLevelTargets: [TopLevelTarget]

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetPlatformInfo.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetPlatformInfo.swift
@@ -35,11 +35,6 @@ struct BazelTargetConfigurationInfo: Hashable {
     /// e.g. darwin_arm64-dbg-macos-arm64-min15.0-applebin_macos-ST-d1334902beb6
     let configurationName: String
 
-    /// The configuration name that should actually apply when compiling a library.
-    /// Only relevant when not passing --compile-top-level.
-    /// e.g. darwin_arm64-dbg-macos-arm64-min15.0
-    let effectiveConfigurationName: String
-
     let minimumOsVersion: String
     let platform: String
     let cpuArch: String

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -606,19 +606,8 @@ extension BazelTargetQuerierParserImpl {
         let platform = String(try cpuComponents.getIndexThrowing(0))
         let cpuArch = String(try cpuComponents.getIndexThrowing(1))
 
-        // To support compiling libraries directly, we need to additionally strip out
-        // the transition and distinguisher parts of the configuration name, as those will not
-        // be present when compiling directly.
-
-        // Edge case: rules_apple 4.3.3 dropped configuration distinguishers
-        let stepsToDrop = try configComponents.getIndexThrowing(5).hasPrefix("applebin_") ? 3 : 2
-
-        let configWithoutTransitionOrDistinguisher = configComponents.dropLast(stepsToDrop)
-        let effectiveConfigurationName = configWithoutTransitionOrDistinguisher.joined(separator: "-")
-
         return BazelTargetConfigurationInfo(
             configurationName: mnemonic,
-            effectiveConfigurationName: effectiveConfigurationName,
             minimumOsVersion: minTargetArg,
             platform: platform,
             cpuArch: cpuArch,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -58,6 +58,8 @@ protocol BazelTargetStore: AnyObject {
     func parentConfig(forBSPURI uri: URI) throws -> String
     /// Retrieves the list of top-level labels for a given configuration.
     func topLevelLabels(forConfig configMnemonic: String) throws -> [String]
+    /// Returns the best parent label for a given config, preferring apps over extensions/tests.
+    func preferredTopLevelLabel(forConfig configMnemonic: String) throws -> String
     /// Clears the cache of the store.
     func clearCache()
 }
@@ -166,13 +168,39 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
         return labels
     }
 
+    /// Returns the best parent label for a given config, preferring apps over extensions/tests.
+    func preferredTopLevelLabel(forConfig configMnemonic: String) throws -> String {
+        let labels = try topLevelLabels(forConfig: configMnemonic)
+        guard !labels.isEmpty else {
+            throw BazelTargetStoreError.unableToMapConfigMnemonicToTopLevelLabels(configMnemonic)
+        }
+        // Use topLevelTargets to get rule type info and sort by priority
+        guard let topLevelTargets = cqueryResult?.topLevelTargets else {
+            return labels[0]
+        }
+        // Create a map from label to rule type for labels in this config
+        let labelSet = Set(labels)
+        var labelToPriority: [String: Int] = [:]
+        for (label, ruleType, _) in topLevelTargets {
+            if labelSet.contains(label) {
+                labelToPriority[label] = ruleType.parentBuildPriority
+            }
+        }
+        // Sort labels by priority (lowest priority value = highest preference)
+        let sortedLabels = labels.sorted { (a, b) in
+            let priorityA = labelToPriority[a] ?? Int.max
+            let priorityB = labelToPriority[b] ?? Int.max
+            return priorityA < priorityB
+        }
+        return sortedLabels[0]
+    }
+
     func platformBuildLabelInfo(forBSPURI uri: URI) throws -> BazelTargetPlatformInfo {
         let bazelLabel = try bazelTargetLabel(forBSPURI: uri)
         let configMnemonic = try parentConfig(forBSPURI: uri)
         let config = try topLevelConfigInfo(forConfigMnemonic: configMnemonic)
-        let parents = try topLevelLabels(forConfig: configMnemonic)
-        // Since the config of these parents are all the same, it doesn't matter which one we pick here.
-        let parentToUse = parents[0]
+        // Use preferredTopLevelLabel to get the best parent (app over extension/test)
+        let parentToUse = try preferredTopLevelLabel(forConfig: configMnemonic)
         return BazelTargetPlatformInfo(
             label: bazelLabel,
             topLevelParentLabel: parentToUse,
@@ -278,6 +306,46 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
 }
 
 extension BazelTargetStoreImpl {
+    /// Generates legacy build args for backward compatibility with older VSCode extensions.
+    /// These are the platform flags that were used before the aspect-based approach.
+    static func legacyBuildArgs(
+        config: BazelTargetConfigurationInfo,
+        appleSupportRepoName: String,
+        devDir: String,
+        xcodeVersion: String
+    ) -> [String] {
+        let platform = config.platform
+        let cpuArch = config.cpuArch
+        let minimumOsVersion = config.minimumOsVersion
+        // Special case: macOS is sometimes referred to as Darwin
+        let friendlyPlatName: String = {
+            if platform == "darwin" {
+                return "macos"
+            }
+            return platform
+        }()
+        // Special case: This flag is different for iOS.
+        let cpuFlagName: String = {
+            if platform == "ios" {
+                return "multi_cpus"
+            }
+            return "cpus"
+        }()
+        return [
+            "--platforms=@\(appleSupportRepoName)//platforms:\(friendlyPlatName)_\(cpuArch)",
+            "--\(friendlyPlatName)_\(cpuFlagName)=\(cpuArch)",
+            "--apple_platform_type=\(friendlyPlatName)",
+            "--apple_split_cpu=\(cpuArch)",
+            "--\(friendlyPlatName)_minimum_os=\(minimumOsVersion)",
+            "--cpu=\(platform)_\(cpuArch)",
+            "--minimum_os_version=\(minimumOsVersion)",
+            "--xcode_version=\(xcodeVersion)",
+            "--repo_env=DEVELOPER_DIR=\(devDir)",
+            "--repo_env=USE_CLANG_CL=\(xcodeVersion)",
+            "--repo_env=XCODE_VERSION=\(xcodeVersion)",
+        ]
+    }
+
     private func writeReport(toPath path: String, creatingDirectoryAt directoryPath: String) {
         try? FileManager.default.createDirectory(
             atPath: directoryPath,
@@ -324,32 +392,39 @@ extension BazelTargetStoreImpl {
                     testSources: testSources
                 )
             )
+            // Build invocation using the aspect approach
+            let buildInvocation =
+                "build \(label) --aspects=//.bsp/skbsp_generated:aspect.bzl%platform_deps_aspect --output_groups={OUTPUT_GROUP}"
+            // Legacy build args for backward compatibility with older VSCode extensions
+            let legacyBuildArgs = BazelTargetStoreImpl.legacyBuildArgs(
+                config: topLevelConfig,
+                appleSupportRepoName: initializedConfig.baseConfig.appleSupportRepoName,
+                devDir: initializedConfig.devDir,
+                xcodeVersion: initializedConfig.xcodeVersion
+            )
             reportConfigurations[configMnemonic] = .init(
-                .init(
-                    mnemonic: configMnemonic,
-                    platform: topLevelConfig.platform,
-                    minimumOsVersion: topLevelConfig.minimumOsVersion,
-                    cpuArch: topLevelConfig.cpuArch,
-                    sdkName: topLevelConfig.sdkName,
-                    dependencyBuildArgs: PrepareHandler.buildArgs(
-                        minimumOsVersion: topLevelConfig.minimumOsVersion,
-                        platform: topLevelConfig.platform,
-                        cpuArch: topLevelConfig.cpuArch,
-                        devDir: initializedConfig.devDir,
-                        xcodeVersion: initializedConfig.xcodeVersion,
-                        appleSupportRepoName: initializedConfig.baseConfig.appleSupportRepoName
-                    )
-                )
+                mnemonic: configMnemonic,
+                platform: topLevelConfig.platform,
+                minimumOsVersion: topLevelConfig.minimumOsVersion,
+                cpuArch: topLevelConfig.cpuArch,
+                sdkName: topLevelConfig.sdkName,
+                buildInvocation: buildInvocation,
+                dependencyBuildArgs: legacyBuildArgs
             )
         }
         var reportDependencies: [BazelTargetGraphReport.DependencyTarget] = []
-        if !initializedConfig.baseConfig.compileTopLevel {
-            let dependencyTargets = cqueryResult?.buildTargets ?? []
-            for target in dependencyTargets {
-                guard let label = target.displayName else { continue }
-                let configMnemonic = try parentConfig(forBSPURI: target.id.uri)
-                reportDependencies.append(.init(label: label, configMnemonic: configMnemonic))
-            }
+        let dependencyTargets = cqueryResult?.buildTargets ?? []
+        for target in dependencyTargets {
+            guard let label = target.displayName else { continue }
+            let configMnemonic = try parentConfig(forBSPURI: target.id.uri)
+            let topLevelParent = try preferredTopLevelLabel(forConfig: configMnemonic)
+            reportDependencies.append(
+                .init(
+                    label: label,
+                    configMnemonic: configMnemonic,
+                    topLevelParent: topLevelParent
+                )
+            )
         }
         return BazelTargetGraphReport(
             topLevelTargets: reportTopLevel,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
@@ -99,4 +99,23 @@ public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument, Senda
         default: return false
         }
     }
+
+    /// Priority for selecting which top-level target to use as parent for aspect builds.
+    /// Lower values = higher priority. Apps should be preferred over extensions and tests.
+    var parentBuildPriority: Int {
+        switch self {
+        case .iosApplication, .watchosApplication, .macosApplication, .tvosApplication, .visionosApplication,
+            .macosCommandLineApplication:
+            return 0  // Highest priority: main apps
+        case .iosAppClip:
+            return 1  // App clips are close to apps
+        case .iosExtension, .watchosExtension, .macosExtension, .tvosExtension, .visionosExtension:
+            return 2  // Extensions
+        case .iosUnitTest, .iosUiTest, .watchosUnitTest, .watchosUiTest, .macosUnitTest, .macosUiTest,
+            .tvosUnitTest, .tvosUiTest, .visionosUnitTest, .visionosUiTest:
+            return 3  // Tests
+        case .iosBuildTest, .watchosBuildTest, .macosBuildTest, .tvosBuildTest, .visionosBuildTest:
+            return 4  // Build tests (lowest priority)
+        }
+    }
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -98,27 +98,13 @@ final class PrepareHandler {
                 labelsToBuild = [topLevelLabelsToBuild.sorted()]
                 extraArgs = [[]]
             } else {
-                // Separate top-level targets (build directly) from libraries (use aspect)
-                var topLevelTargets: Set<String> = []
+                // Build libraries using aspect approach through their parent targets.
+                // Note: targets received here are always libraries, not top-level targets.
                 var parentToLibraryLabelsMap: [String: [String]] = [:]
-
                 for info in platformInfo {
-                    if info.label == info.topLevelParentLabel {
-                        // This is a top-level target (app, extension, test) - build directly
-                        topLevelTargets.insert(info.label)
-                    } else {
-                        // This is a library - use aspect approach
-                        parentToLibraryLabelsMap[info.topLevelParentLabel, default: []].append(info.label)
-                    }
+                    parentToLibraryLabelsMap[info.topLevelParentLabel, default: []].append(info.label)
                 }
 
-                // Add direct builds for top-level targets (no aspects needed)
-                if !topLevelTargets.isEmpty {
-                    labelsToBuild.append(topLevelTargets.sorted())
-                    extraArgs.append([])
-                }
-
-                // Add aspect builds for libraries
                 for (parent, libraries) in parentToLibraryLabelsMap {
                     let outputGroups = libraries.map { Self.sanitizeLabel($0) }.joined(separator: ",")
                     labelsToBuild.append([parent])

--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -89,32 +89,44 @@ final class PrepareHandler {
                 title: taskTitle
             )
             didStartTask = true
-            let labelsToBuild: [[String]]
-            let extraArgs: [[String]]
+
+            var labelsToBuild: [[String]] = []
+            var extraArgs: [[String]] = []
             if initializedConfig.baseConfig.compileTopLevel {
-                // We might get repeat labels in this case, so we need to dedupe them.
+                // Build entire top-level targets
                 let topLevelLabelsToBuild = Set(platformInfo.map { $0.topLevelParentLabel })
                 labelsToBuild = [topLevelLabelsToBuild.sorted()]
-                extraArgs = [[]]  // Not applicable in this case
+                extraArgs = [[]]
             } else {
-                // When passing arguments manually, we might be asked to prepare targets
-                // pertaining to different platforms or min-SDK versions. To enable this,
-                // we split the request into multiple Bazel invocations if needed.
-                var argsToLabelsMap: [[String]: [String]] = [:]
-                for labelToBuild in platformInfo {
-                    let args = Self.buildArgs(
-                        minimumOsVersion: labelToBuild.topLevelParentConfig.minimumOsVersion,
-                        platform: labelToBuild.topLevelParentConfig.platform,
-                        cpuArch: labelToBuild.topLevelParentConfig.cpuArch,
-                        devDir: initializedConfig.devDir,
-                        xcodeVersion: initializedConfig.xcodeVersion,
-                        appleSupportRepoName: initializedConfig.baseConfig.appleSupportRepoName
-                    )
-                    argsToLabelsMap[args, default: []].append(labelToBuild.label)
+                // Separate top-level targets (build directly) from libraries (use aspect)
+                var topLevelTargets: Set<String> = []
+                var parentToLibraryLabelsMap: [String: [String]] = [:]
+
+                for info in platformInfo {
+                    if info.label == info.topLevelParentLabel {
+                        // This is a top-level target (app, extension, test) - build directly
+                        topLevelTargets.insert(info.label)
+                    } else {
+                        // This is a library - use aspect approach
+                        parentToLibraryLabelsMap[info.topLevelParentLabel, default: []].append(info.label)
+                    }
                 }
-                let asTuple = argsToLabelsMap.map { ($0.key, $0.value) }
-                labelsToBuild = asTuple.map { $0.1 }
-                extraArgs = asTuple.map { $0.0 }
+
+                // Add direct builds for top-level targets (no aspects needed)
+                if !topLevelTargets.isEmpty {
+                    labelsToBuild.append(topLevelTargets.sorted())
+                    extraArgs.append([])
+                }
+
+                // Add aspect builds for libraries
+                for (parent, libraries) in parentToLibraryLabelsMap {
+                    let outputGroups = libraries.map { Self.sanitizeLabel($0) }.joined(separator: ",")
+                    labelsToBuild.append([parent])
+                    extraArgs.append([
+                        "--aspects=//.bsp/skbsp_generated:aspect.bzl%platform_deps_aspect",
+                        "--output_groups=\(outputGroups)",
+                    ])
+                }
             }
             nonisolated(unsafe) let reply = reply
             try build(
@@ -196,59 +208,31 @@ final class PrepareHandler {
         }
     }
 
-    static func buildArgs(
-        minimumOsVersion: String,
-        platform: String,
-        cpuArch: String,
-        devDir: String,
-        xcodeVersion: String,
-        appleSupportRepoName: String
-    ) -> [String] {
-        // As of writing, Bazel does not provides a "build X as if it were a child of Y" flag.
-        // This means that to compile individual libraries accurately, we need to replicate
-        // all the transitions that are applied by ios_application rules and friends.
-        // https://github.com/bazelbuild/rules_apple/blob/716568e34b158d67adf83b64d2cea5ea142b641f/apple/internal/transition_support.bzl#L30
-        let friendlyPlatName: String = {
-            // Special case: macOS is sometimes referred to as Darwin
-            // in the infra, so we need to handle that here. Not an issue for the
-            // other platforms.
-            if platform == "darwin" {
-                return "macos"
-            }
-            return platform
-        }()
-        let cpuFlagName: String = {
-            // Special case 2: This flag is different for iOS.
-            if platform == "ios" {
-                return "multi_cpus"
-            }
-            return "cpus"
-        }()
-        return [
-            "--platforms=@\(appleSupportRepoName)//platforms:\(friendlyPlatName)_\(cpuArch)",
-            "--\(friendlyPlatName)_\(cpuFlagName)=\(cpuArch)",
-            "--apple_platform_type=\(friendlyPlatName)",
-            "--apple_split_cpu=\(cpuArch)",
-            "--\(friendlyPlatName)_minimum_os=\(minimumOsVersion)",
-            "--cpu=\(platform)_\(cpuArch)",
-            "--minimum_os_version=\(minimumOsVersion)",
-            "--xcode_version=\(xcodeVersion)",
-            "--repo_env=DEVELOPER_DIR=\(devDir)",
-            "--repo_env=USE_CLANG_CL=\(xcodeVersion)",
-            "--repo_env=XCODE_VERSION=\(xcodeVersion)",
-        ]
+    /// Converts a Bazel label to a safe output group name with aspect prefix.
+    /// Example: //path/to/library:LibraryName -> aspect_path_to_library_LibraryName
+    static func sanitizeLabel(_ label: String) -> String {
+        var sanitized = label
+        if sanitized.hasPrefix("//") {
+            sanitized = String(sanitized.dropFirst(2))
+        }
+        return "aspect_"
+            + sanitized
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: ".", with: "_")
     }
 
     func makeTaskTitle(
         for platformInfo: [BazelTargetPlatformInfo],
         compileTopLevel: Bool
     ) -> String {
-        guard compileTopLevel else {
-            let targetLabels = platformInfo.map { $0.label }
-            let targetNames = targetLabels.joined(separator: ", ")
-            return "sourcekit-bazel-bsp: Building \(targetLabels.count) target(s): \(targetNames)"
+        guard !compileTopLevel else {
+            let topLevelLabels = Set(platformInfo.map { $0.topLevelParentLabel }).sorted()
+            let topLevelNames = topLevelLabels.joined(separator: ", ")
+            return "sourcekit-bazel-bsp: Building \(topLevelLabels.count) top-level target(s): \(topLevelNames)"
         }
-        let targetLabels = Set(platformInfo.map { $0.topLevelParentLabel }).sorted()
+        let targetLabels = platformInfo.map { $0.label }
         let targetNames = targetLabels.joined(separator: ", ")
         return "sourcekit-bazel-bsp: Building \(targetLabels.count) target(s): \(targetNames)"
     }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -160,9 +160,7 @@ final class BazelTargetCompilerArgsExtractor {
         let processedArgs = _processCompilerArguments(
             rawArguments: targetAction.arguments,
             sdkRoot: sdkRoot,
-            strategy: strategy,
-            originalConfigName: platformInfo.topLevelParentConfig.configurationName,
-            effectiveConfigName: platformInfo.topLevelParentConfig.effectiveConfigurationName
+            strategy: strategy
         )
 
         logger.debug("Finished processing compiler arguments")
@@ -258,9 +256,7 @@ extension BazelTargetCompilerArgsExtractor {
     private func _processCompilerArguments(
         rawArguments: [String],
         sdkRoot: String,
-        strategy: ParsingStrategy,
-        originalConfigName: String,
-        effectiveConfigName: String
+        strategy: ParsingStrategy
     ) -> [String] {
         let devDir = config.devDir
         let rootUri = config.rootUri
@@ -352,15 +348,7 @@ extension BazelTargetCompilerArgsExtractor {
             // Transform bazel-out/ paths
             // FIXME: How to be sure this is actually the placeholder and not an actual "bazel-out" folder?
             if arg.contains("bazel-out/") {
-                var transformedArg = arg.replacingOccurrences(of: "bazel-out/", with: outputPath + "/")
-                // If compiling libraries individually, we need to also map the full apps' conf name
-                // with the one that will be used in practice.
-                if !config.baseConfig.compileTopLevel {
-                    transformedArg = transformedArg.replacingOccurrences(
-                        of: "/\(originalConfigName)/",
-                        with: "/\(effectiveConfigName)/"
-                    )
-                }
+                let transformedArg = arg.replacingOccurrences(of: "bazel-out/", with: outputPath + "/")
                 compilerArguments.append(transformedArg)
                 index += 1
                 continue

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -45,7 +45,7 @@ package struct BaseServerConfig: Equatable {
         aqueryFlags: [String] = [],
         queryFlags: [String] = [],
         filesToWatch: String?,
-        compileTopLevel: Bool,
+        compileTopLevel: Bool = false,
         topLevelRulesToDiscover: [TopLevelRuleType] = TopLevelRuleType.allCases,
         dependencyRulesToDiscover: [DependencyRuleType] = DependencyRuleType.allCases,
         topLevelTargetsToExclude: [String] = [],

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -75,7 +75,7 @@ struct Serve: AsyncParsableCommand {
 
     @Flag(
         help:
-            "Instead of attempting to build targets individually, build the top-level parent. If your project contains build_test targets for your individual libraries and you're passing them as the top-level targets for the BSP, you can use this flag to build those targets directly for better predictability and caching."
+            "When enabled, builds entire top-level targets instead of individual libraries. This is slower but may be needed for certain build configurations."
     )
     var compileTopLevel: Bool = false
 

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -41,9 +41,7 @@ struct BazelTargetCompilerArgsExtractorTests {
         self.aqueryResult = aqueryResult
     }
 
-    private static func makeMockExtractor(
-        compileTopLevel: Bool = false
-    ) -> BazelTargetCompilerArgsExtractor {
+    private static func makeMockExtractor() -> BazelTargetCompilerArgsExtractor {
         let mockRootUri = "/Users/user/Documents/demo-ios-project"
         let mockDevDir = "/Applications/Xcode.app/Contents/Developer"
         let mockOutputPath = "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out"
@@ -61,8 +59,7 @@ struct BazelTargetCompilerArgsExtractorTests {
                 bazelWrapper: "bazel",
                 targets: ["//HelloWorld"],
                 indexFlags: [],
-                filesToWatch: nil,
-                compileTopLevel: compileTopLevel
+                filesToWatch: nil
             ),
             rootUri: mockRootUri,
             workspaceName: "_main",
@@ -237,32 +234,6 @@ struct BazelTargetCompilerArgsExtractorTests {
         #expect(error?.localizedDescription == "Target //HelloWorld:SomethingElseLib not found in the aquery output.")
     }
 
-    @Test
-    func compilingTopLevelKeepsFullConfigName() throws {
-        // If the base config has compileTopLevel to true, then the output is the same
-        // with the difference that we don't need to sanitize the config name.
-        let extractor = Self.makeMockExtractor(
-            compileTopLevel: true
-        )
-        let result = try extractor.extractCompilerArgs(
-            fromAquery: aqueryResult,
-            forTarget: BazelTargetPlatformInfo(
-                label: "//HelloWorld:HelloWorldLib",
-                topLevelParentLabel: "//HelloWorld:HelloWorld",
-                topLevelParentConfig: helloWorldConfig
-            ),
-            withStrategy: .swiftModule,
-        )
-        #expect(
-            result
-                == expectedSwiftResult.map {
-                    $0.replacingOccurrences(
-                        of: "ios_sim_arm64-dbg-ios-sim_arm64-min17.0",
-                        with: "ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300"
-                    )
-                }
-        )
-    }
 }
 
 // MARK: - Example inputs and expected results
@@ -277,11 +248,11 @@ let expectedSwiftResult: [String] = [
     "/Applications/Xcode.app/Contents/Developer=/PLACEHOLDER_DEVELOPER_DIR",
     "-emit-object",
     "-output-file-map",
-    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0/bin/HelloWorld/HelloWorldLib.output_file_map.json",
+    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300/bin/HelloWorld/HelloWorldLib.output_file_map.json",
     "-Xfrontend",
     "-no-clang-module-breadcrumbs",
     "-emit-module-path",
-    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0/bin/HelloWorld/HelloWorldLib.swiftmodule",
+    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300/bin/HelloWorld/HelloWorldLib.swiftmodule",
     "-enforce-exclusivity=checked",
     "-Xfrontend",
     "-const-gather-protocols-file",
@@ -302,12 +273,12 @@ let expectedSwiftResult: [String] = [
     "-file-compilation-dir",
     ".",
     "-module-cache-path",
-    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0/bin/_swift_module_cache",
-    "-I/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0/bin/HelloWorld",
+    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300/bin/_swift_module_cache",
+    "-I/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300/bin/HelloWorld",
     "-Xcc",
     "-iquote.",
     "-Xcc",
-    "-iquote/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0/bin",
+    "-iquote/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300/bin",
     "-Xcc",
     "-fmodule-map-file=/Users/user/Documents/demo-ios-project/HelloWorld/TodoObjCSupport/Sources/module.modulemap",
     "-Xfrontend",
@@ -374,10 +345,10 @@ let expectedObjCResult: [String] = [
     "-iquote",
     ".",
     "-iquote",
-    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0/bin",
+    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300/bin",
     "-MD",
     "-MF",
-    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0/bin/HelloWorld/_objs/TodoObjCSupport/arc/SKObjCUtils.d",
+    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300/bin/HelloWorld/_objs/TodoObjCSupport/arc/SKObjCUtils.d",
     "-DOS_IOS",
     "-fno-autolink",
     "-isysroot",
@@ -403,7 +374,7 @@ let expectedObjCResult: [String] = [
     "-D__TIME__=\"redacted\"",
     "HelloWorld/TodoObjCSupport/Sources/SKObjCUtils.m",
     "-o",
-    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0/bin/HelloWorld/_objs/TodoObjCSupport/arc/SKObjCUtils.o",
+    "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300/bin/HelloWorld/_objs/TodoObjCSupport/arc/SKObjCUtils.o",
     "-index-store-path",
     "/private/var/tmp/_bazel_user/hash123/execroot/__main__/bazel-out/_global_index_store",
     "-working-directory",

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
@@ -344,7 +344,6 @@ struct BazelTargetQuerierParserImplTests {
             result.topLevelConfigMnemonicToInfoMap[iosMnemonic]
                 == BazelTargetConfigurationInfo(
                     configurationName: "ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-2842469f5300",
-                    effectiveConfigurationName: "ios_sim_arm64-dbg-ios-sim_arm64-min17.0",
                     minimumOsVersion: "17.0",
                     platform: "ios",
                     cpuArch: "sim_arm64",
@@ -357,7 +356,6 @@ struct BazelTargetQuerierParserImplTests {
             result.topLevelConfigMnemonicToInfoMap[macOsMnemonic]
                 == BazelTargetConfigurationInfo(
                     configurationName: "darwin_arm64-dbg-macos-arm64-min15.0-ST-3b9f41d61db6",
-                    effectiveConfigurationName: "darwin_arm64-dbg-macos-arm64-min15.0",
                     minimumOsVersion: "15.0",
                     platform: "darwin",
                     cpuArch: "arm64",
@@ -370,7 +368,6 @@ struct BazelTargetQuerierParserImplTests {
             result.topLevelConfigMnemonicToInfoMap[watchOsMnemonic]
                 == BazelTargetConfigurationInfo(
                     configurationName: "watchos_arm64-dbg-watchos-arm64-min7.0-ST-f4f2bb7e56ed",
-                    effectiveConfigurationName: "watchos_arm64-dbg-watchos-arm64-min7.0",
                     minimumOsVersion: "7.0",
                     platform: "watchos",
                     cpuArch: "arm64",

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -63,7 +63,6 @@ struct BazelTargetQuerierTests {
             aqueryFlags: aqueryFlags,
             queryFlags: queryFlags,
             filesToWatch: nil,
-            compileTopLevel: false,
             topLevelTargetsToExclude: topLevelTargetsToExclude,
             dependencyTargetsToExclude: dependencyTargetsToExclude
         )

--- a/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetStoreFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetStoreFake.swift
@@ -83,6 +83,10 @@ final class BazelTargetStoreFake: BazelTargetStore {
         unimplemented()
     }
 
+    func preferredTopLevelLabel(forConfig configMnemonic: String) throws -> String {
+        unimplemented()
+    }
+
     func clearCache() {
         clearCacheCalled = true
     }

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -34,8 +34,7 @@ struct InitializeHandlerTests {
             bazelWrapper: "mybazel",
             targets: ["//HelloWorld"],
             indexFlags: ["--config=index"],
-            filesToWatch: nil,
-            compileTopLevel: false
+            filesToWatch: nil
         )
 
         let fullRootUri = "file:///path/to/project"
@@ -96,8 +95,7 @@ struct InitializeHandlerTests {
             bazelWrapper: "mybazel",
             targets: ["//HelloWorld"],
             indexFlags: [],
-            filesToWatch: nil,
-            compileTopLevel: false
+            filesToWatch: nil
         )
 
         let fullRootUri = "file:///path/to/project"
@@ -142,8 +140,7 @@ struct InitializeHandlerTests {
             bazelWrapper: "mybazel",
             targets: ["//HelloWorld"],
             indexFlags: ["--config=index1", "--config=index2"],
-            filesToWatch: nil,
-            compileTopLevel: false
+            filesToWatch: nil
         )
 
         let fullRootUri = "file:///path/to/project"

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -36,8 +36,7 @@ struct PrepareHandlerTests {
             bazelWrapper: "bazel",
             targets: ["//HelloWorld", "//HelloWorld2"],
             indexFlags: ["--config=index"],
-            filesToWatch: nil,
-            compileTopLevel: false
+            filesToWatch: nil
         )
 
         let initializedConfig = InitializedServerConfig(
@@ -132,133 +131,10 @@ struct PrepareHandlerTests {
         #expect(ranCommands[0].cwd == rootUri)
     }
 
-    func providesCorrectFlagsForiOSTargets() {
-        let actualFlags = PrepareHandler.buildArgs(
-            minimumOsVersion: "15.0",
-            platform: "ios",
-            cpuArch: "arm64",
-            devDir: "/Applications/Xcode.app/Contents/Developer",
-            xcodeVersion: "17B100",
-            appleSupportRepoName: "apple_support"
-        )
-        #expect(
-            actualFlags == [
-                "--platforms=@apple_support//platforms:ios_arm64",
-                "--ios_multi_cpus=arm64",
-                "--apple_platform_type=ios",
-                "--apple_split_cpu=arm64",
-                "--ios_minimum_os=15.0",
-                "--cpu=ios_arm64",
-                "--minimum_os_version=15.0",
-                "--xcode_version=17B100",
-                "--repo_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer",
-                "--repo_env=USE_CLANG_CL=17B100",
-                "--repo_env=XCODE_VERSION=17B100",
-            ]
-        )
-    }
-
-    func providesCorrectFlagsForWatchOSTargets() {
-        let actualFlags = PrepareHandler.buildArgs(
-            minimumOsVersion: "15.0",
-            platform: "watchos",
-            cpuArch: "x86_64",
-            devDir: "/Applications/Xcode.app/Contents/Developer",
-            xcodeVersion: "17B100",
-            appleSupportRepoName: "apple_support"
-        )
-        #expect(
-            actualFlags == [
-                "--platforms=@apple_support//platforms:watchos_x86_64",
-                "--watchos_cpus=x86_64",
-                "--apple_platform_type=watchos",
-                "--apple_split_cpu=x86_64",
-                "--watchos_minimum_os=15.0",
-                "--cpu=watchos_x86_64",
-                "--minimum_os_version=15.0",
-                "--xcode_version=17B100",
-                "--repo_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer",
-                "--repo_env=USE_CLANG_CL=17B100",
-                "--repo_env=XCODE_VERSION=17B100",
-            ]
-        )
-    }
-
-    func providesCorrectFlagsForMacOSTargets() {
-        let actualFlags = PrepareHandler.buildArgs(
-            minimumOsVersion: "15.0",
-            platform: "darwin",
-            cpuArch: "arm64",
-            devDir: "/Applications/Xcode.app/Contents/Developer",
-            xcodeVersion: "17B100",
-            appleSupportRepoName: "apple_support"
-        )
-        #expect(
-            actualFlags == [
-                "--platforms=@apple_support//platforms:macos_arm64",
-                "--macos_cpus=arm64",
-                "--apple_platform_type=macos",
-                "--apple_split_cpu=arm64",
-                "--macos_minimum_os=15.0",
-                "--cpu=darwin_arm64",
-                "--minimum_os_version=15.0",
-                "--xcode_version=17B100",
-                "--repo_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer",
-                "--repo_env=USE_CLANG_CL=17B100",
-                "--repo_env=XCODE_VERSION=17B100",
-            ]
-        )
-    }
-
-    func providesCorrectFlagsForTVOSTargets() {
-        let actualFlags = PrepareHandler.buildArgs(
-            minimumOsVersion: "15.0",
-            platform: "tvos",
-            cpuArch: "sim_arm64",
-            devDir: "/Applications/Xcode.app/Contents/Developer",
-            xcodeVersion: "17B100",
-            appleSupportRepoName: "apple_support"
-        )
-        #expect(
-            actualFlags == [
-                "--platforms=@apple_support//platforms:tvos_sim_arm64",
-                "--tvos_cpus=sim_arm64",
-                "--apple_platform_type=tvos",
-                "--apple_split_cpu=sim_arm64",
-                "--tvos_minimum_os=15.0",
-                "--cpu=tvos_sim_arm64",
-                "--minimum_os_version=15.0",
-                "--xcode_version=17B100",
-                "--repo_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer",
-                "--repo_env=USE_CLANG_CL=17B100",
-                "--repo_env=XCODE_VERSION=17B100",
-            ]
-        )
-    }
-
-    func providesCorrectFlagsForVisionOSTargets() {
-        let actualFlags = PrepareHandler.buildArgs(
-            minimumOsVersion: "15.0",
-            platform: "visionos",
-            cpuArch: "sim_arm64",
-            devDir: "/Applications/Xcode.app/Contents/Developer",
-            xcodeVersion: "17B100",
-            appleSupportRepoName: "apple_support"
-        )
-        #expect(
-            actualFlags == [
-                "--platforms=@apple_support//platforms:visionos_sim_arm64",
-                "--visionos_cpus=sim_arm64",
-                "--apple_platform_type=visionos",
-                "--apple_split_cpu=sim_arm64",
-                "--visionos_minimum_os=15.0",
-                "--cpu=visionos_sim_arm64",
-                "--minimum_os_version=15.0",
-                "--xcode_version=17B100",
-                "--repo_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer",
-                "--repo_env=USE_CLANG_CL=17B100",
-                "--repo_env=XCODE_VERSION=17B100",
-            ]
-        )
+    @Test
+    func sanitizesLabelCorrectly() {
+        #expect(PrepareHandler.sanitizeLabel("//path/to/library:LibraryName") == "aspect_path_to_library_LibraryName")
+        #expect(PrepareHandler.sanitizeLabel("//path/to/library") == "aspect_path_to_library")
+        #expect(PrepareHandler.sanitizeLabel("//path-with-dashes:Target.Name") == "aspect_path_with_dashes_Target_Name")
     }
 }

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -15,8 +15,6 @@ def _setup_sourcekit_bsp_impl(ctx):
         bsp_config_argv.append(target)
     bsp_config_argv.append("--bazel-wrapper")
     bsp_config_argv.append(ctx.attr.bazel_wrapper)
-    if ctx.attr.compile_top_level:
-        bsp_config_argv.append("--compile-top-level")
     for index_flag in ctx.attr.index_flags:
         bsp_config_argv.append("--index-flag")
         bsp_config_argv.append(index_flag)
@@ -45,6 +43,8 @@ def _setup_sourcekit_bsp_impl(ctx):
     if ctx.attr.apple_support_repo_name:
         bsp_config_argv.append("--apple-support-repo-name")
         bsp_config_argv.append(ctx.attr.apple_support_repo_name)
+    if ctx.attr.compile_top_level:
+        bsp_config_argv.append("--compile-top-level")
     ctx.actions.expand_template(
         template = ctx.file._bsp_config_template,
         output = rendered_bsp_config,
@@ -172,10 +172,6 @@ setup_sourcekit_bsp = rule(
             doc = "The number of targets to prepare in parallel. If not provided, will default to 1.",
             mandatory = False,
         ),
-        "compile_top_level": attr.bool(
-            doc = "Instead of attempting to build targets individually, build the top-level parent. If your project contains build_test targets for your individual libraries and you're passing them as the top-level targets for the BSP, you can use this flag to build those targets directly for better predictability and caching.",
-            default = False,
-        ),
         "lsp_timeout": attr.int(
             doc = "A custom timeout value to provide to sourcekit-lsp when waiting for responses from the BSP.",
             mandatory = False,
@@ -187,6 +183,10 @@ setup_sourcekit_bsp = rule(
         "merge_lsp_config": attr.bool(
             doc = "If set to true, the generated .sourcekit-lsp/config.json will merge with any existing contents instead of fully overriding the file.",
             default = True,
+        ),
+        "compile_top_level": attr.bool(
+            doc = "When enabled, builds entire top-level targets instead of using the aspect-based approach for individual libraries. This is slower but may be needed for certain build configurations.",
+            default = False,
         ),
     },
 )

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -15,6 +15,8 @@ def _setup_sourcekit_bsp_impl(ctx):
         bsp_config_argv.append(target)
     bsp_config_argv.append("--bazel-wrapper")
     bsp_config_argv.append(ctx.attr.bazel_wrapper)
+    if ctx.attr.compile_top_level:
+        bsp_config_argv.append("--compile-top-level")
     for index_flag in ctx.attr.index_flags:
         bsp_config_argv.append("--index-flag")
         bsp_config_argv.append(index_flag)
@@ -43,8 +45,6 @@ def _setup_sourcekit_bsp_impl(ctx):
     if ctx.attr.apple_support_repo_name:
         bsp_config_argv.append("--apple-support-repo-name")
         bsp_config_argv.append(ctx.attr.apple_support_repo_name)
-    if ctx.attr.compile_top_level:
-        bsp_config_argv.append("--compile-top-level")
     ctx.actions.expand_template(
         template = ctx.file._bsp_config_template,
         output = rendered_bsp_config,
@@ -172,6 +172,10 @@ setup_sourcekit_bsp = rule(
             doc = "The number of targets to prepare in parallel. If not provided, will default to 1.",
             mandatory = False,
         ),
+        "compile_top_level": attr.bool(
+            doc = "When enabled, builds entire top-level targets instead of using the aspect-based approach for individual libraries. This is slower but may be needed for certain build configurations. If your project contains build_test targets for your individual libraries and you're passing them as the top-level targets for the BSP, you can use this flag to build those targets directly for better predictability and caching.",
+            default = False,
+        ),
         "lsp_timeout": attr.int(
             doc = "A custom timeout value to provide to sourcekit-lsp when waiting for responses from the BSP.",
             mandatory = False,
@@ -183,10 +187,6 @@ setup_sourcekit_bsp = rule(
         "merge_lsp_config": attr.bool(
             doc = "If set to true, the generated .sourcekit-lsp/config.json will merge with any existing contents instead of fully overriding the file.",
             default = True,
-        ),
-        "compile_top_level": attr.bool(
-            doc = "When enabled, builds entire top-level targets instead of using the aspect-based approach for individual libraries. This is slower but may be needed for certain build configurations.",
-            default = False,
         ),
     },
 )

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -103,9 +103,12 @@ def _platform_deps_aspect_impl(target, ctx):
     for attr in _PROPAGATION_ATTRS:
         if hasattr(ctx.rule.attr, attr):
             deps = getattr(ctx.rule.attr, attr)
+            if deps == None:
+                continue
             deps_list = deps if type(deps) == "list" else [deps]
             for dep in deps_list:
-                _collect_dep_outputs(dep, transitive_outputs, transitive_output_groups)
+                if dep != None:
+                    _collect_dep_outputs(dep, transitive_outputs, transitive_output_groups)
 
     target_outputs = depset(direct_outputs + source_files, transitive = transitive_outputs)
 

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -19,7 +19,128 @@ lsp_folder_path="$BUILD_WORKSPACE_DIRECTORY/.sourcekit-lsp"
 should_merge_lsp_config="%merge_lsp_config_env%"
 
 mkdir -p "$bsp_folder_path"
+mkdir -p "$bsp_folder_path/skbsp_generated"
 mkdir -p "$lsp_folder_path"
+
+# Create empty BUILD file to make skbsp_generated a valid Bazel package
+touch "$bsp_folder_path/skbsp_generated/BUILD"
+
+# Write the platform deps aspect for library builds
+# This aspect ensures consistent action keys between full app builds and individual library builds
+cat > "$bsp_folder_path/skbsp_generated/aspect.bzl" << 'ASPECT_EOF'
+"""Aspect for collecting platform dependencies with per-target output groups.
+
+This aspect creates individual output groups for each dependency, allowing
+you to build a full app but only output specific libraries with correct
+platform configuration (iOS, tvOS, watchOS).
+"""
+
+ASPECT_OUTPUT_GROUP_PREFIX = "aspect_"
+
+_PROPAGATION_ATTRS = [
+    "deps",
+    "private_deps",
+    "implementation_deps",
+    "extensions",
+    "frameworks",
+    "app_intents",
+    "watch_application",
+]
+
+def _strip_leading_chars(s, chars):
+    for _ in range(len(s)):
+        if s and s[0] in chars:
+            s = s[1:]
+        else:
+            break
+    return s
+
+def _is_aspect_output_group(group_name):
+    clean_name = _strip_leading_chars(group_name, "@_")
+    return clean_name.startswith(ASPECT_OUTPUT_GROUP_PREFIX)
+
+PlatformDepsInfo = provider(
+    doc = "Provider for collecting platform-specific dependency outputs.",
+    fields = {
+        "label": "Label of the target",
+        "outputs": "Depset of output files from transitive dependencies.",
+    },
+)
+
+def _sanitize_label(label):
+    label_str = str(label)
+    label_str = _strip_leading_chars(label_str, "/@")
+    sanitized = label_str.replace("/", "_").replace(":", "_").replace("-", "_").replace(".", "_")
+    return ASPECT_OUTPUT_GROUP_PREFIX + sanitized
+
+def _collect_dep_outputs(dep, transitive_outputs, transitive_output_groups):
+    if PlatformDepsInfo not in dep:
+        return
+    transitive_outputs.append(dep[PlatformDepsInfo].outputs)
+    if OutputGroupInfo in dep:
+        for group_name in dir(dep[OutputGroupInfo]):
+            if _is_aspect_output_group(group_name):
+                output_group = getattr(dep[OutputGroupInfo], group_name, None)
+                if type(output_group) == "depset":
+                    existing = transitive_output_groups.get(group_name, [])
+                    existing.append(output_group)
+                    transitive_output_groups[group_name] = existing
+
+def _platform_deps_aspect_impl(target, ctx):
+    direct_outputs = []
+    if DefaultInfo in target:
+        direct_outputs = target[DefaultInfo].files.to_list()
+
+    source_files = []
+    if hasattr(ctx.rule.attr, "srcs"):
+        for src in ctx.rule.attr.srcs:
+            if hasattr(src, "files"):
+                source_files.extend(src.files.to_list())
+
+    transitive_outputs = []
+    transitive_output_groups = {}
+
+    for attr in _PROPAGATION_ATTRS:
+        if hasattr(ctx.rule.attr, attr):
+            deps = getattr(ctx.rule.attr, attr)
+            deps_list = deps if type(deps) == "list" else [deps]
+            for dep in deps_list:
+                _collect_dep_outputs(dep, transitive_outputs, transitive_output_groups)
+
+    target_outputs = depset(direct_outputs + source_files, transitive = transitive_outputs)
+
+    output_groups = {
+        "platform_deps": target_outputs,
+    }
+
+    target_label = ctx.label
+    target_group_name = _sanitize_label(target_label)
+    output_groups[target_group_name] = target_outputs
+
+    label_str = str(target_label)
+    if ":" in label_str:
+        package_path = label_str.split(":")[0]
+        shorthand_name = _sanitize_label(package_path)
+        if shorthand_name != target_group_name:
+            output_groups[shorthand_name] = target_outputs
+
+    for group_name, group_depsets in transitive_output_groups.items():
+        output_groups[group_name] = depset(transitive = group_depsets)
+
+    return [
+        PlatformDepsInfo(
+            outputs = target_outputs,
+            label = target_label,
+        ),
+        OutputGroupInfo(**output_groups),
+    ]
+
+platform_deps_aspect = aspect(
+    implementation = _platform_deps_aspect_impl,
+    attr_aspects = _PROPAGATION_ATTRS,
+    provides = [PlatformDepsInfo],
+)
+ASPECT_EOF
 
 target_bsp_config_path="$bsp_folder_path/skbsp.json"
 target_sourcekit_bazel_bsp_path="$bsp_folder_path/sourcekit-bazel-bsp"


### PR DESCRIPTION
## Summary                                                                                                                                                               
- Use Bazel aspects to build libraries through their parent app/test targets for cache consistency
- Libraries are built with `--aspects` and `--output_groups` flags pointing to the parent                                                                                
- Top-level targets (apps, extensions, tests) are built directly without aspects                                                                                         
- Generate `aspect.bzl` to `.bsp/skbsp_generated/` during setup                                                                                                          
- Add `parentBuildPriority` to prefer apps over extensions when selecting parent
- Removed legacy `dependencyBuildArgs` backward compatibility (now always uses aspect approach)