### PR TITLE
Small perf / readme follow-ups to the aspects logic

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -189,12 +189,14 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
 
         // We can now properly connect each top-level label to its configuration id.
         var topLevelTargets: [(String, TopLevelRuleType, String)] = []
+        var topLevelLabelToRuleTypeMap: [String: TopLevelRuleType] = [:]
         for (label, ruleType) in allTopLevelLabels {
             guard let configMnemonic = topLevelLabelToConfigMap[label] else {
                 logger.error("Missing info for \(label) in topLevelLabelToConfigMap. This should not happen.")
                 continue
             }
             topLevelTargets.append((label, ruleType, configMnemonic))
+            topLevelLabelToRuleTypeMap[label] = ruleType
         }
 
         guard !topLevelTargets.isEmpty else {
@@ -386,6 +388,7 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
         return ProcessedCqueryResult(
             buildTargets: buildTargets.map { $0.0 },
             topLevelTargets: topLevelTargets,
+            topLevelLabelToRuleTypeMap: topLevelLabelToRuleTypeMap,
             bspURIsToBazelLabelsMap: bspURIsToBazelLabelsMap,
             bspURIsToSrcsMap: bspURIsToSrcsMap,
             srcToBspURIsMap: srcToBspURIsMap,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedCqueryResult.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedCqueryResult.swift
@@ -26,6 +26,7 @@ private let logger = makeFileLevelBSPLogger()
 struct ProcessedCqueryResult {
     let buildTargets: [BuildTarget]
     let topLevelTargets: [(String, TopLevelRuleType, String)]
+    let topLevelLabelToRuleTypeMap: [String: TopLevelRuleType]
     let bspURIsToBazelLabelsMap: [URI: String]
     let bspURIsToSrcsMap: [URI: SourcesItem]
     let srcToBspURIsMap: [URI: [URI]]
@@ -98,6 +99,7 @@ struct ProcessedCqueryResult {
         let result = ProcessedCqueryResult(
             buildTargets: buildTargets,
             topLevelTargets: topLevelTargets,
+            topLevelLabelToRuleTypeMap: topLevelLabelToRuleTypeMap,
             bspURIsToBazelLabelsMap: bspURIsToBazelLabelsMap,
             bspURIsToSrcsMap: _bspURIsToSrcsMap,
             srcToBspURIsMap: _srcToBspURIsMap,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/TopLevelRuleType.swift
@@ -109,13 +109,21 @@ public enum TopLevelRuleType: String, CaseIterable, ExpressibleByArgument, Senda
             return 0  // Highest priority: main apps
         case .iosAppClip:
             return 1  // App clips are close to apps
-        case .iosExtension, .watchosExtension, .macosExtension, .tvosExtension, .visionosExtension:
-            return 2  // Extensions
+        case .iosBuildTest, .watchosBuildTest, .macosBuildTest, .tvosBuildTest, .visionosBuildTest:
+            return 2  // Build tests
         case .iosUnitTest, .iosUiTest, .watchosUnitTest, .watchosUiTest, .macosUnitTest, .macosUiTest,
             .tvosUnitTest, .tvosUiTest, .visionosUnitTest, .visionosUiTest:
             return 3  // Tests
-        case .iosBuildTest, .watchosBuildTest, .macosBuildTest, .tvosBuildTest, .visionosBuildTest:
-            return 4  // Build tests (lowest priority)
+        case .iosExtension, .watchosExtension, .macosExtension, .tvosExtension, .visionosExtension:
+            return 2  // Extensions (lowest priority)
         }
+    }
+}
+
+extension Sequence where Element == (String, TopLevelRuleType) {
+    /// Returns the label with the highest parent build priority.
+    /// Returns nil if the sequence is empty.
+    func labelWithHighestBuildPriority() -> String? {
+        return self.min(by: { $0.1.parentBuildPriority < $1.1.parentBuildPriority })?.0
     }
 }

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -75,7 +75,7 @@ struct Serve: AsyncParsableCommand {
 
     @Flag(
         help:
-            "When enabled, builds entire top-level targets instead of individual libraries. This is slower but may be needed for certain build configurations."
+            "When enabled, builds entire top-level targets instead of using the aspect-based approach for individual libraries. This is slower but may be needed for certain build configurations. If your project contains build_test targets for your individual libraries and you're passing them as the top-level targets for the BSP, you can use this flag to build those targets directly for better predictability and caching."
     )
     var compileTopLevel: Bool = false
 

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -32,6 +32,7 @@ struct BazelTargetQuerierTests {
     private static let emptyProcessedCqueryResult = ProcessedCqueryResult(
         buildTargets: [],
         topLevelTargets: [],
+        topLevelLabelToRuleTypeMap: [:],
         bspURIsToBazelLabelsMap: [:],
         bspURIsToSrcsMap: [:],
         srcToBspURIsMap: [:],

--- a/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetStoreFake.swift
+++ b/Tests/SourceKitBazelBSPTests/Fakes/BazelTargetStoreFake.swift
@@ -83,6 +83,10 @@ final class BazelTargetStoreFake: BazelTargetStore {
         unimplemented()
     }
 
+    func topLevelRuleType(forLabel label: String) throws -> TopLevelRuleType {
+        unimplemented()
+    }
+
     func preferredTopLevelLabel(forConfig configMnemonic: String) throws -> String {
         unimplemented()
     }

--- a/Tests/SourceKitBazelBSPTests/LabelBuildPriorityTests.swift
+++ b/Tests/SourceKitBazelBSPTests/LabelBuildPriorityTests.swift
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Testing
+
+@testable import SourceKitBazelBSP
+
+@Suite
+struct LabelBuildPriorityTests {
+    @Test
+    func emptySequence_returnsNil() {
+        let items: [(String, TopLevelRuleType)] = []
+        #expect(items.labelWithHighestBuildPriority() == nil)
+    }
+
+    @Test
+    func singleElement_returnsThatLabel() {
+        let items: [(String, TopLevelRuleType)] = [
+            ("//app:MyApp", .iosUnitTest)
+        ]
+        #expect(items.labelWithHighestBuildPriority() == "//app:MyApp")
+    }
+    @Test
+    func prefersApp() {
+        let items: [(String, TopLevelRuleType)] = [
+            ("//test:UnitTest", .iosUnitTest),
+            ("//ext:Extension", .iosExtension),
+            ("//app:MyApp", .iosApplication),
+            ("//test:BuildTest", .iosBuildTest),
+            ("//clip:AppClip", .iosAppClip),
+        ]
+        #expect(items.labelWithHighestBuildPriority() == "//app:MyApp")
+    }
+
+    @Test
+    func picksFirstWhenMultipleMaxPrio() {
+        let items: [(String, TopLevelRuleType)] = [
+            ("//test:UnitTest", .iosUnitTest),
+            ("//ext:Extension", .iosExtension),
+            ("//app:MyApp", .iosApplication),
+            ("//test:BuildTest", .iosBuildTest),
+            ("//app:MyOtherApp", .iosApplication),
+            ("//clip:AppClip", .iosAppClip),
+        ]
+        #expect(items.labelWithHighestBuildPriority() == "//app:MyApp")
+    }
+}

--- a/Tests/SourceKitBazelBSPTests/ProcessedCqueryResultTests.swift
+++ b/Tests/SourceKitBazelBSPTests/ProcessedCqueryResultTests.swift
@@ -66,6 +66,7 @@ struct ProcessedCqueryResultTests {
         let initialResult = SourceKitBazelBSP.ProcessedCqueryResult(
             buildTargets: [],
             topLevelTargets: [],
+            topLevelLabelToRuleTypeMap: [:],
             bspURIsToBazelLabelsMap: [:],
             bspURIsToSrcsMap: [targetUri: sourcesItem, otherTargetUri: otherSourcesItem],
             srcToBspURIsMap: [fileToDelete: [targetUri], fileToKeep: [targetUri], irrelevantFile: [otherTargetUri]],
@@ -124,6 +125,7 @@ struct ProcessedCqueryResultTests {
         let initialResult = SourceKitBazelBSP.ProcessedCqueryResult(
             buildTargets: [],
             topLevelTargets: [],
+            topLevelLabelToRuleTypeMap: [:],
             bspURIsToBazelLabelsMap: [:],
             bspURIsToSrcsMap: [targetUri: sourcesItem, otherTargetUri: otherSourcesItem],
             srcToBspURIsMap: [fileToKeep: [targetUri], irrelevantFile: [otherTargetUri]],
@@ -187,6 +189,7 @@ struct ProcessedCqueryResultTests {
         let initialResult = SourceKitBazelBSP.ProcessedCqueryResult(
             buildTargets: [],
             topLevelTargets: [],
+            topLevelLabelToRuleTypeMap: [:],
             bspURIsToBazelLabelsMap: [:],
             bspURIsToSrcsMap: [targetUri: sourcesItem, otherTargetUri: otherSourcesItem],
             srcToBspURIsMap: [fileToKeep: [targetUri], fileToDelete: [targetUri], irrelevantFile: [otherTargetUri]],
@@ -256,6 +259,7 @@ struct ProcessedCqueryResultTests {
         let initialResult = SourceKitBazelBSP.ProcessedCqueryResult(
             buildTargets: [],
             topLevelTargets: [],
+            topLevelLabelToRuleTypeMap: [:],
             bspURIsToBazelLabelsMap: [:],
             bspURIsToSrcsMap: [
                 target1Uri: sourcesItem1,
@@ -336,6 +340,7 @@ struct ProcessedCqueryResultTests {
         let initialResult = SourceKitBazelBSP.ProcessedCqueryResult(
             buildTargets: [],
             topLevelTargets: [],
+            topLevelLabelToRuleTypeMap: [:],
             bspURIsToBazelLabelsMap: [:],
             bspURIsToSrcsMap: [
                 target1Uri: sourcesItem1,
@@ -409,6 +414,7 @@ struct ProcessedCqueryResultTests {
         let initialResult = SourceKitBazelBSP.ProcessedCqueryResult(
             buildTargets: [],
             topLevelTargets: [],
+            topLevelLabelToRuleTypeMap: [:],
             bspURIsToBazelLabelsMap: [:],
             bspURIsToSrcsMap: [targetUri: sourcesItem],
             srcToBspURIsMap: [filetoKepp: [targetUri]],


### PR DESCRIPTION
Updates some of the documentation and adds a faster implementation to preferredBuildLabel by adding some additional info to the cqueries.

Also changes the build order to consider build tests as the second max prio.