### PR TITLE
Share the global index store with the main output base

### DIFF
--- a/Example/HelloWorld/MacApp/MacAppTests/TodoItemMacTests.swift
+++ b/Example/HelloWorld/MacApp/MacAppTests/TodoItemMacTests.swift
@@ -23,7 +23,7 @@ import XCTest
 @testable import MacAppLib
 
 class TodoItemMacTests: XCTestCase {
-    func canReferenceMacnlyContent() {
+    func canReferenceMacOnlyContent() {
         let title = "Test Task"
         _ = TodoItem(title: title)
         XCTAssertEqual(TodoItem.macOnlyContent(), "Mac only content")

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -95,6 +95,15 @@ final class InitializeHandler {
         )
         logger.debug("regularOutputBase: \(regularOutputBase, privacy: .public)")
 
+        // Get the base path where rules_swift stores the global index path on the _original_ output base.
+        // This is what we will use for the BSP builds as well.
+        let baseIndexDataFolder: String = try commandRunner.bazel(
+            baseConfig: baseConfig,
+            rootUri: rootUri,
+            cmd: "info output_path"
+        )
+        logger.debug("baseIndexDataFolder: \(baseIndexDataFolder, privacy: .public)")
+
         // Setup the special output base path where we will run indexing commands from.
         // Nesting into a subfolder for easier cleanup. For example: /private/var/tmp/_bazel_<User>/<ProjectHash>/sourcekit-bazel-bsp
         let outputBase: String
@@ -118,6 +127,13 @@ final class InitializeHandler {
             skipIndexFlags: true
         )
         logger.debug("outputPath: \(outputPath, privacy: .public)")
+
+        // Create a symlink for _global_index_store so that the custom output base shares
+        // the index store with the original output base. This allows both regular builds
+        // and BSP builds to share the same index data.
+        let bspIndexStorePath = outputPath + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
+        let originalIndexStorePath = baseIndexDataFolder + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
+        try setupIndexStoreSymlink(from: bspIndexStorePath, to: originalIndexStorePath, with: commandRunner)
 
         // Get the execution root based on the above output base.
         let executionRoot: String = try commandRunner.bazelIndexAction(
@@ -152,6 +168,7 @@ final class InitializeHandler {
             workspaceName: workspaceName,
             outputBase: outputBase,
             outputPath: outputPath,
+            baseIndexDataFolder: baseIndexDataFolder,
             devDir: devDir,
             xcodeVersion: xcodeVersion,
             devToolchainPath: toolchain,
@@ -193,6 +210,28 @@ final class InitializeHandler {
             result[sdkType] = sdkRootPath
         }
         return sdkRootPaths
+    }
+
+    private func setupIndexStoreSymlink(
+        from customPath: String,
+        to originalPath: String,
+        with commandRunner: CommandRunner
+    ) throws {
+        // Remove existing path if it exists (whether file, directory, or symlink)
+        // Using rm -rf to handle all cases, and ignoring errors if path doesn't exist
+        logger.debug("Removing existing index store at \(customPath, privacy: .public) if present")
+        _ = try? commandRunner.run("rm -rf '\(customPath)'")
+
+        // Create parent directory if needed
+        let parentDir = URL(fileURLWithPath: customPath).deletingLastPathComponent().path
+        logger.debug("Ensuring parent directory exists at \(parentDir, privacy: .public)")
+        _ = try? commandRunner.run("mkdir -p '\(parentDir)'")
+
+        // Create the symlink
+        logger.debug(
+            "Creating index store symlink from \(customPath, privacy: .public) to \(originalPath, privacy: .public)"
+        )
+        _ = try commandRunner.run("ln -s '\(originalPath)' '\(customPath)'")
     }
 
     func buildResponse(

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -95,15 +95,6 @@ final class InitializeHandler {
         )
         logger.debug("regularOutputBase: \(regularOutputBase, privacy: .public)")
 
-        // Get the base path where rules_swift stores the global index path on the _original_ output base.
-        // This is what we will use for the BSP builds as well.
-        let baseIndexDataFolder: String = try commandRunner.bazel(
-            baseConfig: baseConfig,
-            rootUri: rootUri,
-            cmd: "info output_path"
-        )
-        logger.debug("baseIndexDataFolder: \(baseIndexDataFolder, privacy: .public)")
-
         // Setup the special output base path where we will run indexing commands from.
         // Nesting into a subfolder for easier cleanup. For example: /private/var/tmp/_bazel_<User>/<ProjectHash>/sourcekit-bazel-bsp
         let outputBase: String
@@ -131,11 +122,22 @@ final class InitializeHandler {
         // Create a symlink for _global_index_store so that the custom output base shares
         // the index store with the original output base. This allows both regular builds
         // and BSP builds to share the same index data.
+        let baseIndexDataFolder: String
         if baseConfig.sharedIndexStore && !baseConfig.noExtraOutputBase {
+            // Get the base path where rules_swift stores the global index path on the _original_ output base.
+            // This is what we will use for the BSP builds as well.
+            baseIndexDataFolder = try commandRunner.bazel(
+                baseConfig: baseConfig,
+                rootUri: rootUri,
+                cmd: "info output_path"
+            )
+            logger.debug("baseIndexDataFolder: \(baseIndexDataFolder, privacy: .public)")
             let bspIndexStorePath = outputPath + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
             let originalIndexStorePath =
                 baseIndexDataFolder + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
             try setupIndexStoreSymlink(from: bspIndexStorePath, to: originalIndexStorePath, with: commandRunner)
+        } else {
+            baseIndexDataFolder = outputPath
         }
 
         // Get the execution root based on the above output base.

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -94,50 +94,51 @@ final class InitializeHandler {
             fileURLWithPath: try commandRunner.bazel(baseConfig: baseConfig, rootUri: rootUri, cmd: "info output_base")
         )
         logger.debug("regularOutputBase: \(regularOutputBase, privacy: .public)")
+        let regularOutputPath: String = try commandRunner.bazel(
+            baseConfig: baseConfig,
+            rootUri: rootUri,
+            cmd: "info output_path"
+        )
+        logger.debug("regularOutputPath: \(regularOutputPath, privacy: .public)")
 
         // Setup the special output base path where we will run indexing commands from.
         // Nesting into a subfolder for easier cleanup. For example: /private/var/tmp/_bazel_<User>/<ProjectHash>/sourcekit-bazel-bsp
         let outputBase: String
+        let outputPath: String
         if baseConfig.noExtraOutputBase {
             outputBase = regularOutputBase.path
             logger.debug("Will use the regular output base for all actions")
+            outputPath = regularOutputPath
         } else {
             outputBase =
                 regularOutputBase.appendingPathComponent(
                     "sourcekit-bazel-bsp"
                 ).path
+            outputPath = try commandRunner.bazelIndexAction(
+                baseConfig: baseConfig,
+                outputBase: outputBase,
+                cmd: "info output_path",
+                rootUri: rootUri,
+                skipIndexFlags: true
+            )
         }
         logger.debug("outputBase: \(outputBase, privacy: .public)")
-
-        // Now, get the full output path based on the above output base.
-        let outputPath: String = try commandRunner.bazelIndexAction(
-            baseConfig: baseConfig,
-            outputBase: outputBase,
-            cmd: "info output_path",
-            rootUri: rootUri,
-            skipIndexFlags: true
-        )
         logger.debug("outputPath: \(outputPath, privacy: .public)")
 
         // Create a symlink for _global_index_store so that the custom output base shares
         // the index store with the original output base. This allows both regular builds
         // and BSP builds to share the same index data.
-        let baseIndexDataFolder: String
         if baseConfig.sharedIndexStore && !baseConfig.noExtraOutputBase {
             // Get the base path where rules_swift stores the global index path on the _original_ output base.
             // This is what we will use for the BSP builds as well.
-            baseIndexDataFolder = try commandRunner.bazel(
-                baseConfig: baseConfig,
-                rootUri: rootUri,
-                cmd: "info output_path"
-            )
-            logger.debug("baseIndexDataFolder: \(baseIndexDataFolder, privacy: .public)")
             let bspIndexStorePath = outputPath + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
             let originalIndexStorePath =
-                baseIndexDataFolder + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
+                regularOutputPath + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
             try setupIndexStoreSymlink(from: bspIndexStorePath, to: originalIndexStorePath, with: commandRunner)
-        } else {
-            baseIndexDataFolder = outputPath
+        } else if !baseConfig.sharedIndexStore {
+            // Remove any existing symlink from a previous run with sharedIndexStore enabled
+            let indexStorePath = outputPath + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
+            try removeSymlinkIfPresent(at: indexStorePath, with: commandRunner)
         }
 
         // Get the execution root based on the above output base.
@@ -173,7 +174,7 @@ final class InitializeHandler {
             workspaceName: workspaceName,
             outputBase: outputBase,
             outputPath: outputPath,
-            baseIndexDataFolder: baseIndexDataFolder,
+            originalOutputPath: regularOutputPath,
             devDir: devDir,
             xcodeVersion: xcodeVersion,
             devToolchainPath: toolchain,
@@ -222,22 +223,44 @@ final class InitializeHandler {
         to originalPath: String,
         with commandRunner: CommandRunner
     ) throws {
-        // Remove existing path if it exists (whether file, directory, or symlink)
-        // Using rm -rf to handle all cases, and ignoring errors if path doesn't exist
-        logger.debug("Removing existing index store at \(customPath, privacy: .public) if present")
-        _ = try? commandRunner.run("rm -rf '\(customPath)'")
-
         // Create parent directory if needed
         let parentDir = URL(fileURLWithPath: customPath).deletingLastPathComponent().path
         logger.debug("Ensuring parent directory exists at \(parentDir, privacy: .public)")
         _ = try? commandRunner.run("mkdir -p '\(parentDir)'")
+        logger.debug("Ensuring destination directory exists at \(originalPath, privacy: .public)")
+        _ = try? commandRunner.run("mkdir -p '\(originalPath)'")
 
-        // Create the symlink
+        // Remove existing path if present
+        logger.debug("Removing existing index store at \(customPath, privacy: .public) if present")
+        _ = try? commandRunner.run("mv '\(customPath)' '\(parentDir)/old_indestore.backup'")
+
+        // Need to give the filesystem a moment to finish the rename operation
+        sleep(1)
+
+        // Create the symlink inside the parent directory
+        // ln -s <target> <directory> creates <directory>/<basename(target)> -> <target>
         logger.debug(
             "Creating index store symlink from \(customPath, privacy: .public) to \(originalPath, privacy: .public)"
         )
+        _ = try commandRunner.run("ln -s '\(originalPath)' '\(parentDir)'")
+        _ = try? commandRunner.run("rm -rf '\(parentDir)/old_indestore.backup'")
+    }
 
-        _ = try commandRunner.run("ln -s '\(originalPath)' '\(customPath)'")
+    private func removeSymlinkIfPresent(
+        at path: String,
+        with commandRunner: CommandRunner
+    ) throws {
+        // Check if the path is a symlink and remove it if so
+        // This handles the case where a previous run had sharedIndexStore enabled
+        // readlink returns exit code 0 only if the path is a symlink
+        let process = try commandRunner.run("readlink '\(path)'")
+        // Wait for the process to exit
+        let (_, _): (String, String) = process.outputs()
+        let isSymlink = process.wrappedProcess.terminationStatus == 0
+        if isSymlink {
+            logger.debug("Removing existing symlink at \(path, privacy: .public)")
+            _ = try? commandRunner.run("rm '\(path)'")
+        }
     }
 
     func buildResponse(

--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -131,9 +131,12 @@ final class InitializeHandler {
         // Create a symlink for _global_index_store so that the custom output base shares
         // the index store with the original output base. This allows both regular builds
         // and BSP builds to share the same index data.
-        let bspIndexStorePath = outputPath + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
-        let originalIndexStorePath = baseIndexDataFolder + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
-        try setupIndexStoreSymlink(from: bspIndexStorePath, to: originalIndexStorePath, with: commandRunner)
+        if baseConfig.sharedIndexStore && !baseConfig.noExtraOutputBase {
+            let bspIndexStorePath = outputPath + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
+            let originalIndexStorePath =
+                baseIndexDataFolder + "/" + InitializedServerConfig.rulesSwiftIndexStoreFolderName
+            try setupIndexStoreSymlink(from: bspIndexStorePath, to: originalIndexStorePath, with: commandRunner)
+        }
 
         // Get the execution root based on the above output base.
         let executionRoot: String = try commandRunner.bazelIndexAction(
@@ -231,6 +234,7 @@ final class InitializeHandler {
         logger.debug(
             "Creating index store symlink from \(customPath, privacy: .public) to \(originalPath, privacy: .public)"
         )
+
         _ = try commandRunner.run("ln -s '\(originalPath)' '\(customPath)'")
     }
 

--- a/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/BaseServerConfig.swift
@@ -38,6 +38,7 @@ package struct BaseServerConfig: Equatable {
     let dependencyTargetsToExclude: [String]
     let appleSupportRepoName: String
     let noExtraOutputBase: Bool
+    let sharedIndexStore: Bool
 
     package init(
         bazelWrapper: String,
@@ -52,7 +53,8 @@ package struct BaseServerConfig: Equatable {
         topLevelTargetsToExclude: [String] = [],
         dependencyTargetsToExclude: [String] = [],
         appleSupportRepoName: String = "apple_support",
-        noExtraOutputBase: Bool = false
+        noExtraOutputBase: Bool = false,
+        sharedIndexStore: Bool = false
     ) {
         self.bazelWrapper = bazelWrapper
         self.targets = targets
@@ -67,5 +69,6 @@ package struct BaseServerConfig: Equatable {
         self.dependencyTargetsToExclude = dependencyTargetsToExclude
         self.appleSupportRepoName = appleSupportRepoName
         self.noExtraOutputBase = noExtraOutputBase
+        self.sharedIndexStore = sharedIndexStore
     }
 }

--- a/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
@@ -22,11 +22,16 @@ import Foundation
 /// The full configuration of the server, including all information needed to operate the BSP.
 /// Created by the BSP based on the initial `BaseServerConfig`` when the LSP sends us the `initialize` request.
 struct InitializedServerConfig: Equatable {
+
+    static let rulesSwiftIndexStoreFolderName = "_global_index_store"
+    static let lspIndexDatabaseFolderName = "_global_index_database"
+
     let baseConfig: BaseServerConfig
     let rootUri: String
     let workspaceName: String
     let outputBase: String
     let outputPath: String
+    let baseIndexDataFolder: String
     let devDir: String
     let xcodeVersion: String
     let devToolchainPath: String
@@ -34,10 +39,10 @@ struct InitializedServerConfig: Equatable {
     let sdkRootPaths: [String: String]
 
     var indexDatabasePath: String {
-        outputPath + "/_global_index_database"
+        baseIndexDataFolder + "/" + Self.lspIndexDatabaseFolderName
     }
 
     var indexStorePath: String {
-        outputPath + "/_global_index_store"
+        baseIndexDataFolder + "/" + Self.rulesSwiftIndexStoreFolderName
     }
 }

--- a/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
+++ b/Sources/SourceKitBazelBSP/Server/InitializedServerConfig.swift
@@ -31,18 +31,19 @@ struct InitializedServerConfig: Equatable {
     let workspaceName: String
     let outputBase: String
     let outputPath: String
-    let baseIndexDataFolder: String
+    let originalOutputPath: String
     let devDir: String
     let xcodeVersion: String
     let devToolchainPath: String
     let executionRoot: String
     let sdkRootPaths: [String: String]
 
+    // Always store the database on the main output base for easier cleanup.
     var indexDatabasePath: String {
-        baseIndexDataFolder + "/" + Self.lspIndexDatabaseFolderName
+        originalOutputPath + "/" + Self.lspIndexDatabaseFolderName
     }
 
     var indexStorePath: String {
-        baseIndexDataFolder + "/" + Self.rulesSwiftIndexStoreFolderName
+        outputPath + "/" + Self.rulesSwiftIndexStoreFolderName
     }
 }

--- a/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
+++ b/Sources/sourcekit-bazel-bsp/Commands/Serve.swift
@@ -105,6 +105,12 @@ struct Serve: AsyncParsableCommand {
     )
     var experimentalNoExtraOutputBase: Bool = false
 
+    @Flag(
+        help:
+            "(EXPERIMENTAL) If enabled, the BSP will create a symlink so that the BSP's output base shares the index store with the main output base. This allows both regular builds and BSP builds to share the same index data. Has no effect if --experimental-no-extra-output-base is enabled."
+    )
+    var experimentalSharedIndexStore: Bool = false
+
     func run() throws {
         logger.info("`serve` invoked, initializing BSP server...")
 
@@ -130,7 +136,8 @@ struct Serve: AsyncParsableCommand {
             topLevelTargetsToExclude: topLevelTargetToExclude,
             dependencyTargetsToExclude: dependencyTargetToExclude,
             appleSupportRepoName: appleSupportRepoName,
-            noExtraOutputBase: experimentalNoExtraOutputBase
+            noExtraOutputBase: experimentalNoExtraOutputBase,
+            sharedIndexStore: experimentalSharedIndexStore
         )
 
         logger.debug("Initializing BSP with targets: \(targets)")

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -65,6 +65,7 @@ struct BazelTargetCompilerArgsExtractorTests {
             workspaceName: "_main",
             outputBase: mockOutputBase,
             outputPath: mockOutputPath,
+            baseIndexDataFolder: mockOutputPath,
             devDir: mockDevDir,
             xcodeVersion: mockXcodeVersion,
             devToolchainPath: mockDevToolchainPath,

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -65,7 +65,7 @@ struct BazelTargetCompilerArgsExtractorTests {
             workspaceName: "_main",
             outputBase: mockOutputBase,
             outputPath: mockOutputPath,
-            baseIndexDataFolder: mockOutputPath,
+            originalOutputPath: mockOutputPath,
             devDir: mockDevDir,
             xcodeVersion: mockXcodeVersion,
             devToolchainPath: mockDevToolchainPath,

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -73,6 +73,7 @@ struct BazelTargetQuerierTests {
             workspaceName: "_main",
             outputBase: "/path/to/output/base",
             outputPath: "/path/to/output/path",
+            baseIndexDataFolder: "/path/to/regular/output/path",
             devDir: "/path/to/dev/dir",
             xcodeVersion: "17B100",
             devToolchainPath: "/path/to/toolchain",

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -73,7 +73,7 @@ struct BazelTargetQuerierTests {
             workspaceName: "_main",
             outputBase: "/path/to/output/base",
             outputPath: "/path/to/output/path",
-            baseIndexDataFolder: "/path/to/regular/output/path",
+            originalOutputPath: "/path/to/regular/output/path",
             devDir: "/path/to/dev/dir",
             xcodeVersion: "17B100",
             devToolchainPath: "/path/to/toolchain",

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -65,6 +65,14 @@ struct InitializeHandlerTests {
         commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
         commandRunner.setResponse(for: "xcrun --sdk iphonesimulator --show-sdk-path", response: "sdkiossim")
 
+        // Mock symlink setup commands
+        commandRunner.setResponse(for: "rm -rf '\(outputPath)/_global_index_store'", response: "")
+        commandRunner.setResponse(for: "mkdir -p '\(outputPath)'", response: "")
+        commandRunner.setResponse(
+            for: "ln -s '\(baseIndexDataFolder)/_global_index_store' '\(outputPath)/_global_index_store'",
+            response: ""
+        )
+
         let handler = InitializeHandler(baseConfig: baseConfig, commandRunner: commandRunner)
 
         let request = try mockRequest(fullRootUri)
@@ -79,6 +87,7 @@ struct InitializeHandlerTests {
                     workspaceName: "_main",
                     outputBase: outputBase + "/sourcekit-bazel-bsp",
                     outputPath: outputPath,
+                    baseIndexDataFolder: baseIndexDataFolder,
                     devDir: devDir,
                     xcodeVersion: xcodeVersion,
                     devToolchainPath: toolchain,
@@ -106,6 +115,7 @@ struct InitializeHandlerTests {
         let xcodeVersion: String = "17B100"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
+        commandRunner.setResponse(for: "mybazel info output_path", cwd: rootUri, response: baseIndexDataFolder)
         commandRunner.setResponse(
             for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,
@@ -122,6 +132,14 @@ struct InitializeHandlerTests {
         commandRunner.setResponse(
             for: "xcodebuild -version | grep 'Build version' | awk '{print $3}'",
             response: xcodeVersion
+        )
+
+        // Mock symlink setup commands
+        commandRunner.setResponse(for: "rm -rf '\(outputPath)/_global_index_store'", response: "")
+        commandRunner.setResponse(for: "mkdir -p '\(outputPath)'", response: "")
+        commandRunner.setResponse(
+            for: "ln -s '\(baseIndexDataFolder)/_global_index_store' '\(outputPath)/_global_index_store'",
+            response: ""
         )
 
         let handler = InitializeHandler(baseConfig: baseConfig, commandRunner: commandRunner)
@@ -151,6 +169,7 @@ struct InitializeHandlerTests {
         let xcodeVersion: String = "17B100"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
+        commandRunner.setResponse(for: "mybazel info output_path", cwd: rootUri, response: baseIndexDataFolder)
         commandRunner.setResponse(
             for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -46,7 +46,10 @@ struct InitializeHandlerTests {
         let xcodeVersion: String = "17B100"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
+        let regularOutputPath = "/_bazel_user/abc123/execroot/_main/bazel-out"
+
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
+        commandRunner.setResponse(for: "mybazel info output_path", cwd: rootUri, response: regularOutputPath)
         commandRunner.setResponse(
             for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,
@@ -64,6 +67,12 @@ struct InitializeHandlerTests {
         )
         commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
         commandRunner.setResponse(for: "xcrun --sdk iphonesimulator --show-sdk-path", response: "sdkiossim")
+        // readlink returns non-zero exit code when path is not a symlink
+        commandRunner.setResponse(
+            for: "readlink '\(outputPath)/_global_index_store'",
+            response: "",
+            exitCode: 1
+        )
 
         let handler = InitializeHandler(baseConfig: baseConfig, commandRunner: commandRunner)
 
@@ -71,7 +80,6 @@ struct InitializeHandlerTests {
 
         let config = try handler.makeInitializedConfig(fromRequest: request, baseConfig: baseConfig)
 
-        // When sharedIndexStore is false (default), baseIndexDataFolder equals outputPath
         #expect(
             config
                 == InitializedServerConfig(
@@ -80,7 +88,7 @@ struct InitializeHandlerTests {
                     workspaceName: "_main",
                     outputBase: outputBase + "/sourcekit-bazel-bsp",
                     outputPath: outputPath,
-                    baseIndexDataFolder: outputPath,
+                    originalOutputPath: regularOutputPath,
                     devDir: devDir,
                     xcodeVersion: xcodeVersion,
                     devToolchainPath: toolchain,
@@ -107,7 +115,10 @@ struct InitializeHandlerTests {
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
         let xcodeVersion: String = "17B100"
 
+        let regularOutputPath = "/_bazel_user/abc123/execroot/_main/bazel-out"
+
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
+        commandRunner.setResponse(for: "mybazel info output_path", cwd: rootUri, response: regularOutputPath)
         commandRunner.setResponse(
             for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,
@@ -124,6 +135,12 @@ struct InitializeHandlerTests {
         commandRunner.setResponse(
             for: "xcodebuild -version | grep 'Build version' | awk '{print $3}'",
             response: xcodeVersion
+        )
+        // readlink returns non-zero exit code when path is not a symlink
+        commandRunner.setResponse(
+            for: "readlink '\(outputPath)/_global_index_store'",
+            response: "",
+            exitCode: 1
         )
 
         let handler = InitializeHandler(baseConfig: baseConfig, commandRunner: commandRunner)
@@ -149,10 +166,12 @@ struct InitializeHandlerTests {
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
         let outputPath = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main/bazel-out"
+        let regularOutputPath = "/_bazel_user/abc123/execroot/_main/bazel-out"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
         let xcodeVersion: String = "17B100"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
+        commandRunner.setResponse(for: "mybazel info output_path", cwd: rootUri, response: regularOutputPath)
         commandRunner.setResponse(
             for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,
@@ -169,6 +188,12 @@ struct InitializeHandlerTests {
         commandRunner.setResponse(
             for: "xcodebuild -version | grep 'Build version' | awk '{print $3}'",
             response: xcodeVersion
+        )
+        // readlink returns non-zero exit code when path is not a symlink
+        commandRunner.setResponse(
+            for: "readlink '\(outputPath)/_global_index_store'",
+            response: "",
+            exitCode: 1
         )
 
         let handler = InitializeHandler(baseConfig: baseConfig, commandRunner: commandRunner)

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -40,6 +40,7 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
+        let baseIndexDataFolder = "/_bazel_user/abc123/execroot/_main/bazel-out"
         let outputPath = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let executionRoot = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main"
         let devDir = "/Applications/Xcode.app/Contents/Developer"
@@ -47,6 +48,7 @@ struct InitializeHandlerTests {
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
+        commandRunner.setResponse(for: "mybazel info output_path", cwd: rootUri, response: baseIndexDataFolder)
         commandRunner.setResponse(
             for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,
@@ -64,14 +66,6 @@ struct InitializeHandlerTests {
         )
         commandRunner.setResponse(for: "xcrun --find swift", response: toolchain + "usr/bin/swift")
         commandRunner.setResponse(for: "xcrun --sdk iphonesimulator --show-sdk-path", response: "sdkiossim")
-
-        // Mock symlink setup commands
-        commandRunner.setResponse(for: "rm -rf '\(outputPath)/_global_index_store'", response: "")
-        commandRunner.setResponse(for: "mkdir -p '\(outputPath)'", response: "")
-        commandRunner.setResponse(
-            for: "ln -s '\(baseIndexDataFolder)/_global_index_store' '\(outputPath)/_global_index_store'",
-            response: ""
-        )
 
         let handler = InitializeHandler(baseConfig: baseConfig, commandRunner: commandRunner)
 
@@ -110,6 +104,7 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
+        let baseIndexDataFolder = "/_bazel_user/abc123/execroot/_main/bazel-out"
         let outputPath = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
         let xcodeVersion: String = "17B100"
@@ -134,14 +129,6 @@ struct InitializeHandlerTests {
             response: xcodeVersion
         )
 
-        // Mock symlink setup commands
-        commandRunner.setResponse(for: "rm -rf '\(outputPath)/_global_index_store'", response: "")
-        commandRunner.setResponse(for: "mkdir -p '\(outputPath)'", response: "")
-        commandRunner.setResponse(
-            for: "ln -s '\(baseIndexDataFolder)/_global_index_store' '\(outputPath)/_global_index_store'",
-            response: ""
-        )
-
         let handler = InitializeHandler(baseConfig: baseConfig, commandRunner: commandRunner)
 
         let request = try mockRequest(fullRootUri)
@@ -164,6 +151,7 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
+        let baseIndexDataFolder = "/_bazel_user/abc123/execroot/_main/bazel-out"
         let outputPath = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
         let xcodeVersion: String = "17B100"

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -40,7 +40,6 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
-        let baseIndexDataFolder = "/_bazel_user/abc123/execroot/_main/bazel-out"
         let outputPath = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let executionRoot = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main"
         let devDir = "/Applications/Xcode.app/Contents/Developer"
@@ -48,7 +47,6 @@ struct InitializeHandlerTests {
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
-        commandRunner.setResponse(for: "mybazel info output_path", cwd: rootUri, response: baseIndexDataFolder)
         commandRunner.setResponse(
             for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,
@@ -73,6 +71,7 @@ struct InitializeHandlerTests {
 
         let config = try handler.makeInitializedConfig(fromRequest: request, baseConfig: baseConfig)
 
+        // When sharedIndexStore is false (default), baseIndexDataFolder equals outputPath
         #expect(
             config
                 == InitializedServerConfig(
@@ -81,7 +80,7 @@ struct InitializeHandlerTests {
                     workspaceName: "_main",
                     outputBase: outputBase + "/sourcekit-bazel-bsp",
                     outputPath: outputPath,
-                    baseIndexDataFolder: baseIndexDataFolder,
+                    baseIndexDataFolder: outputPath,
                     devDir: devDir,
                     xcodeVersion: xcodeVersion,
                     devToolchainPath: toolchain,
@@ -104,13 +103,11 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
-        let baseIndexDataFolder = "/_bazel_user/abc123/execroot/_main/bazel-out"
         let outputPath = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
         let xcodeVersion: String = "17B100"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
-        commandRunner.setResponse(for: "mybazel info output_path", cwd: rootUri, response: baseIndexDataFolder)
         commandRunner.setResponse(
             for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,
@@ -151,13 +148,11 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
-        let baseIndexDataFolder = "/_bazel_user/abc123/execroot/_main/bazel-out"
         let outputPath = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
         let xcodeVersion: String = "17B100"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
-        commandRunner.setResponse(for: "mybazel info output_path", cwd: rootUri, response: baseIndexDataFolder)
         commandRunner.setResponse(
             for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -45,6 +45,7 @@ struct PrepareHandlerTests {
             workspaceName: "_main",
             outputBase: "/tmp/output_base",
             outputPath: "/tmp/output_path",
+            baseIndexDataFolder: "/tmp/regular_output_path",
             devDir: "/Applications/Xcode.app/Contents/Developer",
             xcodeVersion: "17B100",
             devToolchainPath: "/a/b/XcodeDefault.xctoolchain/",

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -45,7 +45,7 @@ struct PrepareHandlerTests {
             workspaceName: "_main",
             outputBase: "/tmp/output_base",
             outputPath: "/tmp/output_path",
-            baseIndexDataFolder: "/tmp/regular_output_path",
+            originalOutputPath: "/tmp/regular_output_path",
             devDir: "/Applications/Xcode.app/Contents/Developer",
             xcodeVersion: "17B100",
             devToolchainPath: "/a/b/XcodeDefault.xctoolchain/",

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -47,6 +47,8 @@ def _setup_sourcekit_bsp_impl(ctx):
         bsp_config_argv.append(ctx.attr.apple_support_repo_name)
     if ctx.attr.experimental_no_extra_output_base:
         bsp_config_argv.append("--experimental-no-extra-output-base")
+    if ctx.attr.experimental_shared_index_store:
+        bsp_config_argv.append("--experimental-shared-index-store")
     ctx.actions.expand_template(
         template = ctx.file._bsp_config_template,
         output = rendered_bsp_config,
@@ -194,6 +196,10 @@ setup_sourcekit_bsp = rule(
         ),
         "experimental_no_extra_output_base": attr.bool(
             doc = "(EXPERIMENTAL) If enabled, the BSP will not create a separate output base for its indexing actions. Can greatly reduce disk usage and improve cache hits at the cost of more pressure on the single Bazel server.",
+            default = False,
+        ),
+        "experimental_shared_index_store": attr.bool(
+            doc = "(EXPERIMENTAL) If enabled, the BSP will create a symlink so that the BSP's output base shares the index store with the main output base. This allows both regular builds and BSP builds to share the same index data. Has no effect if experimental_no_extra_output_base is enabled.",
             default = False,
         ),
     },

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -179,7 +179,7 @@ external_root="${bsp_output_base}/${exec_root_difference}/external"
 # Clean up the old output base if it exists (from before we nested it in the main one)
 if [ -d "$old_bsp_output_base" ]; then
     echo "Cleaning up old output base at $old_bsp_output_base"
-    cd "$WORKSPACE_ROOT" && bazel --output_base="$old_bsp_output_base" clean --expunge &
+    rm -rf "$old_bsp_output_base" > /dev/null 2>&1 &
 fi
 
 # Copy to a temp file first since the source may be a symlink in runfiles


### PR DESCRIPTION
Instead of holding two separate _global_index_stores, this PR makes it so that the BSP index store is a symlink to the original one. This allows regular builds to contribute not only the build cache but also the indexstores themselves to the BSP builds and vice-versa.