### PR TITLE
Avoid creatin BUILD file in skbsp_generated if already exist

### DIFF
--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -22,8 +22,11 @@ mkdir -p "$bsp_folder_path"
 mkdir -p "$bsp_folder_path/skbsp_generated"
 mkdir -p "$lsp_folder_path"
 
-# Create empty BUILD file to make skbsp_generated a valid Bazel package
-touch "$bsp_folder_path/skbsp_generated/BUILD"
+# Create empty BUILD.bazel file to make skbsp_generated a valid Bazel package
+# (skip if one already exists)
+if [ ! -f "$bsp_folder_path/skbsp_generated/BUILD.bazel" ] && [ ! -f "$bsp_folder_path/skbsp_generated/BUILD" ]; then
+    touch "$bsp_folder_path/skbsp_generated/BUILD.bazel"
+fi
 
 # Write the platform deps aspect for library builds
 # This aspect ensures consistent action keys between full app builds and individual library builds


### PR DESCRIPTION
Previously, an empty BUILD file was always created in .bsp/skbsp_generated/. However, an extension or script may generate a BUILD.bazel file in the same directory. To avoid overwriting it, I added a check for this case and switched to using BUILD.bazel instead of BUILD.