### PR TITLE
Nest BSP output base inside the regular Bazel output base

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/InitializeHandler.swift
@@ -96,9 +96,9 @@ final class InitializeHandler {
         logger.debug("regularOutputBase: \(regularOutputBase, privacy: .public)")
 
         // Setup the special output base path where we will run indexing commands from.
-        let regularOutputBaseLastPath = regularOutputBase.lastPathComponent
-        let outputBase = regularOutputBase.deletingLastPathComponent().appendingPathComponent(
-            "\(regularOutputBaseLastPath)-sourcekit-bazel-bsp"
+        // Nesting into a subfolder for easier cleanup. For example: /private/var/tmp/_bazel_<User>/<ProjectHash>/sourcekit-bazel-bsp
+        let outputBase = regularOutputBase.appendingPathComponent(
+            "sourcekit-bazel-bsp"
         ).path
         logger.debug("outputBase: \(outputBase, privacy: .public)")
 

--- a/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/InitializeHandlerTests.swift
@@ -40,20 +40,20 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
-        let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main/bazel-out"
-        let executionRoot = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main"
+        let outputPath = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main/bazel-out"
+        let executionRoot = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main"
         let devDir = "/Applications/Xcode.app/Contents/Developer"
         let xcodeVersion: String = "17B100"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
         commandRunner.setResponse(
-            for: "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info output_path",
+            for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,
             response: outputPath
         )
         commandRunner.setResponse(
-            for: "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info execution_root",
+            for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info execution_root",
             cwd: rootUri,
             response: executionRoot
         )
@@ -77,7 +77,7 @@ struct InitializeHandlerTests {
                     baseConfig: baseConfig,
                     rootUri: rootUri,
                     workspaceName: "_main",
-                    outputBase: outputBase + "-sourcekit-bazel-bsp",
+                    outputBase: outputBase + "/sourcekit-bazel-bsp",
                     outputPath: outputPath,
                     devDir: devDir,
                     xcodeVersion: xcodeVersion,
@@ -101,18 +101,18 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
-        let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main/bazel-out"
+        let outputPath = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
         let xcodeVersion: String = "17B100"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
         commandRunner.setResponse(
-            for: "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info output_path",
+            for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,
             response: outputPath
         )
         commandRunner.setResponse(
-            for: "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info execution_root",
+            for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info execution_root",
             cwd: rootUri,
             response: outputPath
         )
@@ -146,18 +146,18 @@ struct InitializeHandlerTests {
         let fullRootUri = "file:///path/to/project"
         let rootUri = "/path/to/project"
         let outputBase = "/_bazel_user/abc123"
-        let outputPath = "/_bazel_user/abc123-sourcekit-bazel-bsp/execroot/_main/bazel-out"
+        let outputPath = "/_bazel_user/abc123/sourcekit-bazel-bsp/execroot/_main/bazel-out"
         let toolchain = "/a/b/Toolchains/XcodeDefault.xctoolchain/"
         let xcodeVersion: String = "17B100"
 
         commandRunner.setResponse(for: "mybazel info output_base", cwd: rootUri, response: outputBase)
         commandRunner.setResponse(
-            for: "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info output_path",
+            for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info output_path",
             cwd: rootUri,
             response: outputPath
         )
         commandRunner.setResponse(
-            for: "mybazel --output_base=/_bazel_user/abc123-sourcekit-bazel-bsp info execution_root",
+            for: "mybazel --output_base=/_bazel_user/abc123/sourcekit-bazel-bsp info execution_root",
             cwd: rootUri,
             response: outputPath
         )

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -163,9 +163,16 @@ output_path_difference=$(echo "$output_path" | sed "s|$output_base/||")
 exec_root=$(cd "$WORKSPACE_ROOT" && $bazel_wrapper info execution_root)
 exec_root_difference=$(echo "$exec_root" | sed "s|$output_base/||")
 output_path_name=$(echo "$output_path" | sed "s|$exec_root/||")
-bsp_output_base="${output_base}-sourcekit-bazel-bsp"
+old_bsp_output_base="${output_base}-sourcekit-bazel-bsp"
+bsp_output_base="${output_base}/sourcekit-bazel-bsp"
 output_path="${bsp_output_base}/${output_path_difference}"
 external_root="${bsp_output_base}/${exec_root_difference}/external"
+
+# Clean up the old output base if it exists (from before we nested it in the main one)
+if [ -d "$old_bsp_output_base" ]; then
+    echo "Cleaning up old output base at $old_bsp_output_base"
+    cd "$WORKSPACE_ROOT" && bazel --output_base="$old_bsp_output_base" clean --expunge &
+fi
 
 # Copy to a temp file first since the source may be a symlink in runfiles
 lsp_config_tmp=$(mktemp)


### PR DESCRIPTION

## Summary

- Changes the BSP-specific output base from being a sibling directory to being a subfolder of the regular Bazel output base, so it gets cleaned up automatically when the regular output base is removed.
- Updates InitializeHandler and all related tests to reflect the new path structure.

## Motivation
Previously, sourcekit-bazel-bsp created its output base as a sibling directory alongside Bazel's regular output base by appending a -sourcekit-bazel-bsp suffix to the directory name. This meant that running bazel clean --expunge (which removes the regular output base) would leave the BSP output base behind as an orphan, requiring manual cleanup.

By nesting the BSP output base as a subdirectory inside the regular output base, it is automatically included when the parent is removed — whether by bazel clean --expunge, manual deletion, or any other cleanup mechanism.

### Example

Before (sibling):
**regular output**: `/var/tmp/_bazel_sean/a1b2c3d4/`       
**bsp output**: `/var/tmp/_bazel_sean/a1b2c3d4-sourcekit-bazel-bsp/`

After (nested):
**regular output**: `/var/tmp/_bazel_sean/a1b2c3d4/` 
**bsp output**: `/var/tmp/_bazel_sean/a1b2c3d4/sourcekit-bazel-bsp/`
