### PR TITLE
Update testSources + the graph report when new files are added

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -371,18 +371,15 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
             }
         }
 
-        // Use the previously parsed test bundle info to infer which files
+        // This particular information is used later to infer which files
         // belong to which test targets. Used to power test tabs in IDE integrations.
-        var bazelLabelToTestFilesMap: [String: [URI]] = [:]
+        var testTargetToBundleTargetMap: [String: URI] = [:]
         for (testBundle, realTestTarget) in testBundleToRealNameMap {
             let targetHoldingSources = resolveAlias(label: testBundle, from: aliasToLabelMap)
             guard let targetUri = displayNameToURIMap[targetHoldingSources] else {
                 continue
             }
-            guard let sourcesItem = bspURIsToSrcsMap[targetUri] else {
-                continue
-            }
-            bazelLabelToTestFilesMap[realTestTarget] = sourcesItem.sources.map { $0.uri }
+            testTargetToBundleTargetMap[realTestTarget] = targetUri
         }
 
         return ProcessedCqueryResult(
@@ -394,7 +391,7 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
             srcToBspURIsMap: srcToBspURIsMap,
             configurationToTopLevelLabelsMap: configurationToTopLevelLabelsMap,
             bspUriToParentConfigMap: bspUriToParentConfigMap,
-            bazelLabelToTestFilesMap: bazelLabelToTestFilesMap
+            testTargetToBundleTargetMap: testTargetToBundleTargetMap
         )
     }
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -240,12 +240,7 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
         let result = cqueryResult.buildTargets
         cachedTargets = result
 
-        reportQueue.async { [weak self] in
-            guard let self = self else { return }
-            let graphDir = self.initializedConfig.rootUri + "/.bsp/skbsp_generated"
-            let graphPath = graphDir + "/graph.json"
-            self.writeReport(toPath: graphPath, creatingDirectoryAt: graphDir)
-        }
+        writeGraphReportAsync()
 
         return result
     }
@@ -280,6 +275,9 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
         // FIXME: We should try to edit the existing aquery instead of running a new one.
         self.aqueryResult = try processCompilerArguments(from: newCqueryResult)
         self.cqueryResult = newCqueryResult
+
+        writeGraphReportAsync()
+
         return invalidatedTargets
     }
 
@@ -301,6 +299,15 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
 }
 
 extension BazelTargetStoreImpl {
+    private func writeGraphReportAsync() {
+        reportQueue.async { [weak self] in
+            guard let self = self else { return }
+            let graphDir = self.initializedConfig.rootUri + "/.bsp/skbsp_generated"
+            let graphPath = graphDir + "/graph.json"
+            self.writeReport(toPath: graphPath, creatingDirectoryAt: graphDir)
+        }
+    }
+
     private func writeReport(toPath path: String, creatingDirectoryAt directoryPath: String) {
         try? FileManager.default.createDirectory(
             atPath: directoryPath,
@@ -335,9 +342,11 @@ extension BazelTargetStoreImpl {
                     return nil
                 }
             }()
-            let testSources: [String]? = {
+            let testSources: [String]? = try {
                 guard launchType == .test else { return nil }
-                return cqueryResult?.bazelLabelToTestFilesMap[label]?.map { $0.stringValue }
+                guard let bundleTarget = cqueryResult?.testTargetToBundleTargetMap[label] else { return nil }
+                let bundleTargetSrcs = try bazelTargetSrcs(forBSPURI: bundleTarget)
+                return bundleTargetSrcs.sources.map { $0.uri.stringValue }
             }()
             reportTopLevel.append(
                 .init(

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedCqueryResult.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/ProcessedCqueryResult.swift
@@ -32,7 +32,7 @@ struct ProcessedCqueryResult {
     let srcToBspURIsMap: [URI: [URI]]
     let configurationToTopLevelLabelsMap: [String: [String]]
     let bspUriToParentConfigMap: [URI: String]
-    let bazelLabelToTestFilesMap: [String: [URI]]
+    let testTargetToBundleTargetMap: [String: URI]
 
     /// Merges the result of a cquery for added and removed files into the current result.
     /// Makes sure files that are unrelated to known targets are ignored.
@@ -105,7 +105,7 @@ struct ProcessedCqueryResult {
             srcToBspURIsMap: _srcToBspURIsMap,
             configurationToTopLevelLabelsMap: configurationToTopLevelLabelsMap,
             bspUriToParentConfigMap: bspUriToParentConfigMap,
-            bazelLabelToTestFilesMap: bazelLabelToTestFilesMap
+            testTargetToBundleTargetMap: testTargetToBundleTargetMap
         )
         return (result, invalidatedTargets)
     }

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
@@ -310,42 +310,43 @@ struct BazelTargetQuerierParserImplTests {
                 ])
         )
 
-        // Verify bazelLabelToTestFilesMap - maps test targets to their source files
-        // These are the test bundle targets that should have source files mapped
+        // Verify testTargetToBundleTargetMap - maps test targets to their bundle target URIs
+        // These are the test bundle targets that should have their bundle URIs mapped
         let expectedTestTargets = Set([
             "//HelloWorld:HelloWorldTests",
             "//HelloWorld:HelloWorldE2ETests",
             "//HelloWorld:HelloWorldMacTests",
             "//HelloWorld:HelloWorldWatchTests",
         ])
-        let actualTestTargets = Set(result.bazelLabelToTestFilesMap.keys)
+        let actualTestTargets = Set(result.testTargetToBundleTargetMap.keys)
         #expect(
             actualTestTargets == expectedTestTargets,
-            "bazelLabelToTestFilesMap keys don't match expected test targets"
+            "testTargetToBundleTargetMap keys don't match expected test targets"
         )
 
-        // Verify each test target has non-empty source files
+        // Verify each test target maps to a valid bundle target URI
         for testTarget in expectedTestTargets {
-            let sourceFiles = try #require(
-                result.bazelLabelToTestFilesMap[testTarget],
-                "Missing source files for test target: \(testTarget)"
+            let bundleTargetUri = try #require(
+                result.testTargetToBundleTargetMap[testTarget],
+                "Missing bundle target URI for test target: \(testTarget)"
             )
+            // The bundle target URI should exist in bspURIsToSrcsMap
             #expect(
-                !sourceFiles.isEmpty,
-                "Source files should not be empty for test target: \(testTarget)"
+                result.bspURIsToSrcsMap[bundleTargetUri] != nil,
+                "Bundle target URI should be a valid target with sources: \(testTarget)"
             )
         }
 
-        // Verify specific source file mappings
-        // HelloWorldTests should have source files from the HelloWorldTests directory
-        // (HelloWorldTestsLib library sources are in HelloWorldTests/*.swift)
-        let unitTestFiles = try #require(result.bazelLabelToTestFilesMap["//HelloWorld:HelloWorldTests"])
-        #expect(unitTestFiles.contains { $0.stringValue.contains("HelloWorldTests/") })
+        // Verify specific bundle target mappings
+        // HelloWorldTests should map to a bundle target containing test sources
+        let unitTestBundleUri = try #require(result.testTargetToBundleTargetMap["//HelloWorld:HelloWorldTests"])
+        let unitTestSources = try #require(result.bspURIsToSrcsMap[unitTestBundleUri])
+        #expect(unitTestSources.sources.contains { $0.uri.stringValue.contains("HelloWorldTests/") })
 
-        // HelloWorldE2ETests should have source files from the HelloWorldE2ETests directory
-        // (HelloWorldE2ETestsLib library sources are in HelloWorldE2ETests/*.swift)
-        let e2eTestFiles = try #require(result.bazelLabelToTestFilesMap["//HelloWorld:HelloWorldE2ETests"])
-        #expect(e2eTestFiles.contains { $0.stringValue.contains("HelloWorldE2ETests/") })
+        // HelloWorldE2ETests should map to a bundle target containing E2E test sources
+        let e2eTestBundleUri = try #require(result.testTargetToBundleTargetMap["//HelloWorld:HelloWorldE2ETests"])
+        let e2eTestSources = try #require(result.bspURIsToSrcsMap[e2eTestBundleUri])
+        #expect(e2eTestSources.sources.contains { $0.uri.stringValue.contains("HelloWorldE2ETests/") })
     }
 
     @Test

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierTests.swift
@@ -38,7 +38,7 @@ struct BazelTargetQuerierTests {
         srcToBspURIsMap: [:],
         configurationToTopLevelLabelsMap: [:],
         bspUriToParentConfigMap: [:],
-        bazelLabelToTestFilesMap: [:]
+        testTargetToBundleTargetMap: [:]
     )
 
     private static let emptyProcessedAqueryResult = ProcessedAqueryResult(

--- a/Tests/SourceKitBazelBSPTests/ProcessedCqueryResultTests.swift
+++ b/Tests/SourceKitBazelBSPTests/ProcessedCqueryResultTests.swift
@@ -72,7 +72,7 @@ struct ProcessedCqueryResultTests {
             srcToBspURIsMap: [fileToDelete: [targetUri], fileToKeep: [targetUri], irrelevantFile: [otherTargetUri]],
             configurationToTopLevelLabelsMap: [:],
             bspUriToParentConfigMap: [:],
-            bazelLabelToTestFilesMap: [:]
+            testTargetToBundleTargetMap: [:]
         )
 
         let (newResult, invalidatedTargets) = try #require(
@@ -131,7 +131,7 @@ struct ProcessedCqueryResultTests {
             srcToBspURIsMap: [fileToKeep: [targetUri], irrelevantFile: [otherTargetUri]],
             configurationToTopLevelLabelsMap: [:],
             bspUriToParentConfigMap: [:],
-            bazelLabelToTestFilesMap: [:]
+            testTargetToBundleTargetMap: [:]
         )
 
         let (newResult, invalidatedTargets) = try #require(
@@ -195,7 +195,7 @@ struct ProcessedCqueryResultTests {
             srcToBspURIsMap: [fileToKeep: [targetUri], fileToDelete: [targetUri], irrelevantFile: [otherTargetUri]],
             configurationToTopLevelLabelsMap: [:],
             bspUriToParentConfigMap: [:],
-            bazelLabelToTestFilesMap: [:]
+            testTargetToBundleTargetMap: [:]
         )
 
         let (newResult, invalidatedTargets) = try #require(
@@ -272,7 +272,7 @@ struct ProcessedCqueryResultTests {
             ],
             configurationToTopLevelLabelsMap: [:],
             bspUriToParentConfigMap: [:],
-            bazelLabelToTestFilesMap: [:]
+            testTargetToBundleTargetMap: [:]
         )
 
         let (newResult, invalidatedTargets) = try #require(
@@ -352,7 +352,7 @@ struct ProcessedCqueryResultTests {
             ],
             configurationToTopLevelLabelsMap: [:],
             bspUriToParentConfigMap: [:],
-            bazelLabelToTestFilesMap: [:]
+            testTargetToBundleTargetMap: [:]
         )
 
         let (newResult, invalidatedTargets) = try #require(
@@ -420,7 +420,7 @@ struct ProcessedCqueryResultTests {
             srcToBspURIsMap: [filetoKepp: [targetUri]],
             configurationToTopLevelLabelsMap: [:],
             bspUriToParentConfigMap: [:],
-            bazelLabelToTestFilesMap: [:]
+            testTargetToBundleTargetMap: [:]
         )
 
         var response = initialResult.processFileChanges(


### PR DESCRIPTION
We started adding information about test sources to the graph report a couple of PRs ago, but did not handle the case where those files would be added subsequentially. This takes care of that.