### PR TITLE
Apply aspect via wrapper rule instead of CLI --aspects flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The setup instructions for other IDEs (and by extension, Claude Code) will depen
 When building a specific library for indexing, the BSP needs to compile it with the correct platform configuration (iOS, tvOS, etc.) to ensure correctness and proper cache sharing with regular full app builds. The BSP achieves this by using an **aspect** to build libraries _through_ their parent top-level target:
 
 ```
-bazel build //App:MyApp --aspects=//.bsp/skbsp_generated:aspect.bzl%platform_deps_aspect --output_groups=aspect_path_to_MyLibrary
+bazel build //.bsp/skbsp_generated:wrapper_App_MyApp --output_groups=aspect_path_to_MyLibrary
 ```
 
 If this is undesired and/or causes issues with your particular setup, you can pass the `--compile-top-level` flag to make the BSP directly compile the target's **entire parent** instead of using the aspect approach. This can be useful for projects that define fine-grained `*_build_test` targets and providing them as top-level targets for the BSP, as those don't require such workarounds and thus enables maximum predictability and cacheability.

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetGraphReport.swift
@@ -46,8 +46,8 @@ struct BazelTargetGraphReport: Codable, Equatable {
         let minimumOsVersion: String
         let cpuArch: String
         let sdkName: String
-        /// Build invocation template for building dependencies using the aspect approach.
-        /// Format: "build {parent} --aspects=... --output_groups={OUTPUT_GROUP}"
+        /// Build invocation template for building dependencies via wrapper targets.
+        /// Format: "build {wrapper_target} --output_groups={OUTPUT_GROUP}"
         let buildInvocation: String
     }
 

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -307,10 +307,10 @@ extension BazelTargetStoreImpl {
         forTopLevelTargets targets: [(String, TopLevelRuleType, String)]
     ) {
         let uniqueLabels = Set(targets.map { $0.0 }).sorted()
-        var content = "load(\":rules.bzl\", \"platform_deps_targets\")\n\n"
+        var content = "load(\":rules.bzl\", \"platform_deps_wrapper\")\n\n"
         for label in uniqueLabels {
             let wrapperName = BazelLabelSanitizer.wrapperTargetName(forLabel: label)
-            content += "platform_deps_targets(\n"
+            content += "platform_deps_wrapper(\n"
             content += "    name = \"\(wrapperName)\",\n"
             content += "    target = \"\(label)\",\n"
             content += ")\n"

--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetStore.swift
@@ -237,6 +237,8 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
         self.aqueryResult = try processCompilerArguments(from: cqueryResult)
         self.cqueryResult = cqueryResult
 
+        writeWrapperBuildFile(forTopLevelTargets: cqueryResult.topLevelTargets)
+
         let result = cqueryResult.buildTargets
         cachedTargets = result
 
@@ -299,6 +301,31 @@ final class BazelTargetStoreImpl: BazelTargetStore, @unchecked Sendable {
 }
 
 extension BazelTargetStoreImpl {
+    /// Generates a BUILD.bazel file with wrapper targets for each unique top-level target.
+    /// These wrapper targets apply the aspect via rule attribute instead of CLI --aspects.
+    private func writeWrapperBuildFile(
+        forTopLevelTargets targets: [(String, TopLevelRuleType, String)]
+    ) {
+        let uniqueLabels = Set(targets.map { $0.0 }).sorted()
+        var content = "load(\":rules.bzl\", \"platform_deps_targets\")\n\n"
+        for label in uniqueLabels {
+            let wrapperName = BazelLabelSanitizer.wrapperTargetName(forLabel: label)
+            content += "platform_deps_targets(\n"
+            content += "    name = \"\(wrapperName)\",\n"
+            content += "    target = \"\(label)\",\n"
+            content += ")\n"
+        }
+        let buildFilePath = initializedConfig.rootUri + "/.bsp/skbsp_generated/BUILD.bazel"
+        do {
+            try content.write(toFile: buildFilePath, atomically: true, encoding: .utf8)
+            logger.info("Wrapper BUILD.bazel written to \(buildFilePath, privacy: .public)")
+        } catch {
+            logger.error(
+                "Failed to write wrapper BUILD.bazel: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
     private func writeGraphReportAsync() {
         reportQueue.async { [weak self] in
             guard let self = self else { return }
@@ -356,9 +383,10 @@ extension BazelTargetStoreImpl {
                     testSources: testSources
                 )
             )
-            // Build invocation using the aspect approach
+            // Build invocation using the wrapper rule approach
+            let wrapperName = BazelLabelSanitizer.wrapperTargetName(forLabel: label)
             let buildInvocation =
-                "build \(label) --aspects=//.bsp/skbsp_generated:aspect.bzl%platform_deps_aspect --output_groups={OUTPUT_GROUP}"
+                "build //.bsp/skbsp_generated:\(wrapperName) --output_groups={OUTPUT_GROUP}"
             reportConfigurations[configMnemonic] = .init(
                 mnemonic: configMnemonic,
                 platform: topLevelConfig.platform,

--- a/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/PrepareHandler.swift
@@ -107,9 +107,9 @@ final class PrepareHandler {
 
                 for (parent, libraries) in parentToLibraryLabelsMap {
                     let outputGroups = libraries.map { Self.sanitizeLabel($0) }.joined(separator: ",")
-                    labelsToBuild.append([parent])
+                    let wrapperTarget = "//.bsp/skbsp_generated:\(Self.wrapperTargetName(forLabel: parent))"
+                    labelsToBuild.append([wrapperTarget])
                     extraArgs.append([
-                        "--aspects=//.bsp/skbsp_generated:aspect.bzl%platform_deps_aspect",
                         "--output_groups=\(outputGroups)",
                     ])
                 }
@@ -197,16 +197,13 @@ final class PrepareHandler {
     /// Converts a Bazel label to a safe output group name with aspect prefix.
     /// Example: //path/to/library:LibraryName -> aspect_path_to_library_LibraryName
     static func sanitizeLabel(_ label: String) -> String {
-        var sanitized = label
-        if sanitized.hasPrefix("//") {
-            sanitized = String(sanitized.dropFirst(2))
-        }
-        return "aspect_"
-            + sanitized
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: ":", with: "_")
-            .replacingOccurrences(of: "-", with: "_")
-            .replacingOccurrences(of: ".", with: "_")
+        return BazelLabelSanitizer.sanitize(label, prefix: "aspect_")
+    }
+
+    /// Converts a Bazel label to a wrapper target name.
+    /// Example: //path/to/app:MyApp -> wrapper_path_to_app_MyApp
+    static func wrapperTargetName(forLabel label: String) -> String {
+        return BazelLabelSanitizer.wrapperTargetName(forLabel: label)
     }
 
     func makeTaskTitle(

--- a/Sources/SourceKitBazelBSP/SharedUtils/BazelLabelSanitizer.swift
+++ b/Sources/SourceKitBazelBSP/SharedUtils/BazelLabelSanitizer.swift
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// Sanitizes Bazel labels into safe identifiers for use as output group names or target names.
+enum BazelLabelSanitizer {
+    /// Sanitizes a Bazel label with the given prefix.
+    /// Strips leading `//`, replaces `/`, `:`, `-`, `.` with `_`.
+    static func sanitize(_ label: String, prefix: String) -> String {
+        var sanitized = label
+        if sanitized.hasPrefix("//") {
+            sanitized = String(sanitized.dropFirst(2))
+        }
+        return prefix
+            + sanitized
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: ".", with: "_")
+    }
+
+    /// Converts a Bazel label to a wrapper target name.
+    /// Example: //path/to/app:MyApp -> wrapper_path_to_app_MyApp
+    static func wrapperTargetName(forLabel label: String) -> String {
+        return sanitize(label, prefix: "wrapper_")
+    }
+}

--- a/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
+++ b/Tests/SourceKitBazelBSPTests/PrepareHandlerTests.swift
@@ -137,4 +137,11 @@ struct PrepareHandlerTests {
         #expect(PrepareHandler.sanitizeLabel("//path/to/library") == "aspect_path_to_library")
         #expect(PrepareHandler.sanitizeLabel("//path-with-dashes:Target.Name") == "aspect_path_with_dashes_Target_Name")
     }
+
+    @Test
+    func wrapperTargetNameSanitizesCorrectly() {
+        #expect(PrepareHandler.wrapperTargetName(forLabel: "//path/to/app:MyApp") == "wrapper_path_to_app_MyApp")
+        #expect(PrepareHandler.wrapperTargetName(forLabel: "//App:MyApp") == "wrapper_App_MyApp")
+        #expect(PrepareHandler.wrapperTargetName(forLabel: "//path-with-dashes:Target.Name") == "wrapper_path_with_dashes_Target_Name")
+    }
 }

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -148,6 +148,66 @@ platform_deps_aspect = aspect(
 )
 ASPECT_EOF
 
+# Write the wrapper rule for applying the aspect via rule attribute instead of CLI --aspects.
+# This avoids Skyframe cache invalidation from ConfiguredTargetKey instability (bazelbuild/bazel#19914).
+cat > "$bsp_folder_path/skbsp_generated/rules.bzl" << 'RULES_EOF'
+"""Wrapper rule that applies platform_deps_aspect via rule attribute.
+
+By applying the aspect through a rule attribute (not CLI --aspects),
+the ConfiguredTargetKey is stable across builds, preventing potential
+Skyframe cache invalidation (bazelbuild/bazel#19914).
+
+No configuration transition is applied — the app target uses its own
+internal transitions (from ios_application/tvos_application/etc.) to
+configure deps with correct platform settings. This ensures the wrapper
+reuses the same ConfiguredTargetValue nodes as a normal app build.
+"""
+
+load(":aspect.bzl", "platform_deps_aspect")
+
+def _platform_deps_wrapper_impl(ctx):
+    target = ctx.attr.target
+
+    # Forward OutputGroupInfo so --output_groups works on wrapper targets
+    output_groups = {}
+    if OutputGroupInfo in target:
+        for group_name in dir(target[OutputGroupInfo]):
+            group = getattr(target[OutputGroupInfo], group_name, None)
+            if type(group) == "depset":
+                output_groups[group_name] = group
+
+    return [
+        DefaultInfo(files = target[DefaultInfo].files),
+        OutputGroupInfo(**output_groups),
+    ]
+
+_platform_deps_wrapper = rule(
+    implementation = _platform_deps_wrapper_impl,
+    attrs = {
+        "target": attr.label(
+            aspects = [platform_deps_aspect],
+            mandatory = True,
+        ),
+    },
+    doc = "Wrapper that applies platform_deps_aspect via rule attribute for stable caching.",
+)
+
+def platform_deps_targets(name, target, visibility = None):
+    """Create a wrapper target for an app.
+
+    Args:
+        name: Base name for the wrapper target.
+        target: The app target label.
+        visibility: Visibility for the generated target.
+    """
+    _platform_deps_wrapper(
+        name = name,
+        target = target,
+        tags = ["manual"],
+        visibility = visibility or ["//visibility:public"],
+    )
+RULES_EOF
+
 target_bsp_config_path="$bsp_folder_path/skbsp.json"
 target_sourcekit_bazel_bsp_path="$bsp_folder_path/sourcekit-bazel-bsp"
 target_lsp_config_path="$lsp_folder_path/config.json"

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -192,7 +192,7 @@ _platform_deps_wrapper = rule(
     doc = "Wrapper that applies platform_deps_aspect via rule attribute for stable caching.",
 )
 
-def platform_deps_targets(name, target, visibility = None):
+def platform_deps_wrapper(name, target, visibility = None):
     """Create a wrapper target for an app.
 
     Args:


### PR DESCRIPTION
## Summary

* Switch from CLI `--aspects` flag to applying the aspect via a wrapper rule attribute
* Avoid potential Skyframe cache invalidation caused by `ConfiguredTargetKey` instability (bazelbuild/bazel#19914)
* Generate `rules.bzl` with a `platform_deps_wrapper` rule that applies the aspect through its `target` attribute
* Ensure wrapper targets inherit the app's internal transitions (`ios_application` / `tvos_application`) for consistent platform configuration
* Rename `platform_deps_targets` to `platform_deps_wrapper` for clarity

## Context

This builds on #177, which introduced aspect-based builds for library indexing.

The original implementation used the CLI `--aspects` flag, which can lead to cache instability due to `ConfiguredTargetKey` changes between builds.

By applying the aspect through a rule attribute instead of the CLI, the `ConfiguredTargetKey` remains stable across builds, resulting in improved cache hit rates and more predictable incremental behavior.

## Changes

* **BazelTargetStore**

  * Add wrapper target generation logic
  * Introduce `aspectWrapperTargetName(for:)`

* **PrepareHandler**

  * Update to use wrapper targets with `--output_groups` instead of `--aspects`

* **BazelLabelSanitizer**

  * Add new utility for consistent label sanitization shared between Swift and Starlark code

* **rules/setup_sourcekit_bsp.sh.tpl**

  * Generate `rules.bzl` including the new wrapper rule alongside `aspect.bzl`

* **rules/setup_sourcekit_bsp.bzl**

  * Update `compile_top_level` documentation


## Test Plan

* Verify all existing tests pass
* Test library indexing in a real project to confirm aspects continue working correctly
* Confirm wrapper targets are generated under `.bsp/skbsp_generated/` after setup
* Validate stable cache behavior across incremental builds
