### PR TITLE
Dependency graph: Only follow real deps

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/BuildTargets/BazelTargetQuerierParser.swift
@@ -138,6 +138,7 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
         for configuration in cquery.configurations {
             configIdToMnemonicMap[configuration.id] = configuration.mnemonic
         }
+
         for configuredTarget in cquery.results {
             let target = configuredTarget.target
             if target.type == .rule {
@@ -471,17 +472,19 @@ final class BazelTargetQuerierParserImpl: BazelTargetQuerierParser {
         depLabelToUriMap: [String: [(BuildTargetIdentifier, String)]],
         aliasToLabelMap: [String: String]
     ) -> [URI: [String]] {
-        // Step 1: Build a forward dependency graph from ruleInput
-        // Maps each label to its direct dependencies (labels from ruleInput)
+        // Step 1: Build a forward dependency graph from explicit deps attribute
+        // Maps each label to its direct dependencies (labels from deps + implementation_deps)
+        // We use the explicit deps attribute instead of ruleInput because ruleInput includes
+        // all inputs (e.g., test_host for E2E tests), which would incorrectly make E2E tests
+        // appear to depend on the entire test host app's dependency tree.
         var labelToDeps: [String: Set<String>] = [:]
         for configuredTarget in cqueryResults {
             let target = configuredTarget.target
             guard target.type == .rule else { continue }
             let label = target.rule.name
-            // ruleInput contains all direct inputs: deps, srcs, etc.
-            // We only care about dependencies that are also rules (not source files)
-            let deps = Set(target.rule.ruleInput.filter { !$0.contains(".") || $0.contains(":") })
-            labelToDeps[label] = deps
+            let depsAttr = target.rule.attribute.first { $0.name == "deps" }?.stringListValue ?? []
+            let implDeps = target.rule.attribute.first { $0.name == "implementation_deps" }?.stringListValue ?? []
+            labelToDeps[label] = Set(depsAttr + implDeps)
         }
 
         // Step 2: For each top-level target, compute its transitive dependency closure

--- a/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetQuerierParserImplTests.swift
@@ -232,11 +232,11 @@ struct BazelTargetQuerierParserImplTests {
         // iOS targets - verify based on actual dependency relationships, not just config matching
         // ExpandedTemplate and GeneratedDummy are deps of HelloWorldLib, which is dep of HelloWorld.
         // HelloWorldTests deps on HelloWorldTestsLib which deps on HelloWorldLib.
-        // HelloWorldE2ETests has test_host=HelloWorld, so it includes HelloWorld's deps.
+        // HelloWorldE2ETests has test_host=HelloWorld, but test_host is NOT included in deps,
+        // so E2E tests only include their own deps (HelloWorldE2ETestsLib), not the test host's deps.
         #expect(
             getParentLabels(forLabel: "//HelloWorld:ExpandedTemplate")
                 == Set([
-                    "//HelloWorld:HelloWorldE2ETests",
                     "//HelloWorld:HelloWorldTests",
                     "//HelloWorld:HelloWorld",
                 ])
@@ -244,7 +244,6 @@ struct BazelTargetQuerierParserImplTests {
         #expect(
             getParentLabels(forLabel: "//HelloWorld:GeneratedDummy")
                 == Set([
-                    "//HelloWorld:HelloWorldE2ETests",
                     "//HelloWorld:HelloWorldTests",
                     "//HelloWorld:HelloWorld",
                 ])
@@ -252,7 +251,6 @@ struct BazelTargetQuerierParserImplTests {
         #expect(
             getParentLabels(forLabel: "//HelloWorld:HelloWorldLib")
                 == Set([
-                    "//HelloWorld:HelloWorldE2ETests",
                     "//HelloWorld:HelloWorldTests",
                     "//HelloWorld:HelloWorld",
                 ])
@@ -290,32 +288,30 @@ struct BazelTargetQuerierParserImplTests {
         // TodoModels is used by multiple targets across platforms
         // iOS: HelloWorld -> HelloWorldLib -> TodoModelsAlias -> TodoModels
         //      HelloWorldTests -> HelloWorldTestsLib -> HelloWorldLib -> ...
-        //      HelloWorldE2ETests (test_host: HelloWorld) -> ...
+        //      Note: HelloWorldE2ETests is NOT included because test_host is not a dep
         // macOS: HelloWorldMacApp -> MacAppLib -> TodoModels
         //        HelloWorldMacTests -> MacAppTestsLib -> MacAppLib -> ...
         //        HelloWorldMacCLIApp -> MacCLIAppLib -> TodoModels
-        // watchOS: HelloWorldWatchApp -> HelloWorldWatchExtension -> WatchAppLib -> TodoModels
-        //          HelloWorldWatchExtension -> WatchAppLib -> TodoModels
+        // watchOS: HelloWorldWatchExtension -> WatchAppLib -> TodoModels
         //          HelloWorldWatchTests -> WatchAppTestsLib -> WatchAppLib -> ...
+        //          Note: HelloWorldWatchApp is NOT included because extension is not a dep
         #expect(
             getParentLabels(forLabel: "//HelloWorld:TodoModels")
                 == Set([
                     "//HelloWorld:HelloWorldMacTests",
                     "//HelloWorld:HelloWorldMacCLIApp",
                     "//HelloWorld:HelloWorldMacApp",
-                    "//HelloWorld:HelloWorldWatchApp",
                     "//HelloWorld:HelloWorldWatchTests",
                     "//HelloWorld:HelloWorldWatchExtension",
-                    "//HelloWorld:HelloWorldE2ETests",
                     "//HelloWorld:HelloWorldTests",
                     "//HelloWorld:HelloWorld",
                 ])
         )
         // TodoObjCSupport is a dep of HelloWorldLib (iOS only)
+        // Note: HelloWorldE2ETests is NOT included because test_host is not a dep
         #expect(
             getParentLabels(forLabel: "//HelloWorld:TodoObjCSupport")
                 == Set([
-                    "//HelloWorld:HelloWorldE2ETests",
                     "//HelloWorld:HelloWorldTests",
                     "//HelloWorld:HelloWorld",
                 ])
@@ -327,13 +323,13 @@ struct BazelTargetQuerierParserImplTests {
                     "//HelloWorld:HelloWorldE2ETests"
                 ])
         )
-        // watchOS targets - WatchAppLib is dep of HelloWorldWatchExtension, which is dep of HelloWorldWatchApp
+        // watchOS targets - WatchAppLib is dep of HelloWorldWatchExtension
         // HelloWorldWatchTests deps on WatchAppTestsLib which deps on WatchAppLib
+        // Note: HelloWorldWatchApp is NOT included because it uses extension attribute, not deps
         #expect(
             getParentLabels(forLabel: "//HelloWorld:WatchAppLib")
                 == Set([
                     "//HelloWorld:HelloWorldWatchExtension",
-                    "//HelloWorld:HelloWorldWatchApp",
                     "//HelloWorld:HelloWorldWatchTests",
                 ])
         )


### PR DESCRIPTION
Following rule_inputs was causing more to be parsed than necessary.