### PR TITLE
Always map indexes to the execution root, drop restriction on the global index store

### DIFF
--- a/Example/.bazelrc
+++ b/Example/.bazelrc
@@ -20,7 +20,7 @@ common --features=oso_prefix_is_pwd
 common --features=relative_ast_path
 common --features=swift.cacheable_swiftmodules
 common --features=swift.index_while_building
-common --features=swift.use_global_module_cache
+common --features=swift.use_global_index_store
 common --features=swift.emit_swiftsourceinfo
 common --nolegacy_important_outputs
 build --noworker_sandboxing

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://github.com/user-attachments/assets/ca5a448d-03b1-4f8e-9de1-e403cc08953c
 ### Shared Instructions for All IDEs / Models
 
 - Make sure your Bazel project is properly configured to generate the supporting files used for indexing. For more details on that, check how our example project is configured.
-    - The most important part is to **not** use WMO or `swift.use_global_index_store` on regular CLI builds as these will prevent the BSP from indexing the code properly.
+    - The most important part is to **not** use WMO as this will prevent the BSP from indexing the code properly.
 - Add sourcekit-bazel-bsp as a dependency on your `MODULE.bazel` file:
 
 ```python

--- a/rules/setup_sourcekit_bsp.bzl
+++ b/rules/setup_sourcekit_bsp.bzl
@@ -74,8 +74,10 @@ def _setup_sourcekit_bsp_impl(ctx):
 
     prefixMap = {
         "./OUTPUT_PATH_NAME_PLACEHOLDER": "OUTPUT_PATH_PLACEHOLDER",
+        # Using use_global_index_store causes the index files to be relative to the global index store. We need to re-map those to the execution root as well.
+        "../OUTPUT_PATH_NAME_PLACEHOLDER": "OUTPUT_PATH_PLACEHOLDER",
         "./external": "EXTERNAL_ROOT_PLACEHOLDER",
-        ".": "WORKSPACE_ROOT_PLACEHOLDER",
+        ".": "EXECUTION_ROOT_PLACEHOLDER",
     }
     lsp_config_json["index"] = {"indexPrefixMap": prefixMap}
 

--- a/rules/setup_sourcekit_bsp.sh.tpl
+++ b/rules/setup_sourcekit_bsp.sh.tpl
@@ -238,6 +238,7 @@ else
 fi
 output_path="${bsp_output_base}/${output_path_difference}"
 external_root="${bsp_output_base}/${exec_root_difference}/external"
+exec_root="${bsp_output_base}/${exec_root_difference}"
 
 # Clean up the old output base if it exists (from before we nested it in the main one)
 if [ -d "$old_bsp_output_base" ]; then
@@ -251,7 +252,7 @@ cp "$lsp_config_path" "$lsp_config_tmp"
 sed -i '' 's|OUTPUT_PATH_PLACEHOLDER|'"$output_path"'|g' "$lsp_config_tmp"
 sed -i '' 's|EXTERNAL_ROOT_PLACEHOLDER|'"$external_root"'|g' "$lsp_config_tmp"
 sed -i '' 's|OUTPUT_PATH_NAME_PLACEHOLDER|'"$output_path_name"'|g' "$lsp_config_tmp"
-sed -i '' 's|WORKSPACE_ROOT_PLACEHOLDER|'"$WORKSPACE_ROOT"'|g' "$lsp_config_tmp"
+sed -i '' 's|EXECUTION_ROOT_PLACEHOLDER|'"$exec_root"'|g' "$lsp_config_tmp"
 lsp_config_path="${lsp_config_tmp}"
 
 # Update the LSP config if needed


### PR DESCRIPTION
- Maps ../bazel-out to the execution root, dropping a restriction on having to disable the global index store feature
- Map `.` to the execution root instead of the worktree. This was an oversight