### PR TITLE
Fix config mismatch for targets under multiple top-level parents

### DIFF
--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -457,7 +457,7 @@ extension BazelTargetCompilerArgsExtractor {
     }
 }
 
-private extension String {
+extension String {
     /// Strips the Bazel settings transition hash suffix from a configuration mnemonic.
     ///
     /// Bazel appends a `-ST-<hex>` suffix to configuration mnemonics to distinguish builds
@@ -466,7 +466,7 @@ private extension String {
     /// for a given set of settings but differs across top-level targets.
     ///
     /// See: https://bazel.build/extending/config#user-defined-transitions
-    var strippingSettingsTransitionHash: String {
+    fileprivate var strippingSettingsTransitionHash: String {
         self.replacingOccurrences(of: #"-ST-[a-f0-9]+$"#, with: "", options: .regularExpression)
     }
 }

--- a/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
+++ b/Sources/SourceKitBazelBSP/RequestHandlers/SKOptions/BazelTargetCompilerArgsExtractor.swift
@@ -228,6 +228,17 @@ final class BazelTargetCompilerArgsExtractor {
             }
             return config.mnemonic == platformInfo.topLevelParentConfig.configurationName
         }
+        // When a dependency exists under multiple top-level targets, each gets a unique
+        // settings transition hash (the -ST-<hex> suffix in the config mnemonic).
+        // The parent config stored during cquery may not match the one from aquery.
+        // Fall back to matching without the ST hash — same platform/arch/minOS.
+        if candidateActions.isEmpty {
+            let requestedBase = platformInfo.topLevelParentConfig.configurationName.strippingSettingsTransitionHash
+            candidateActions = actions.filter {
+                guard let config = aquery.configurations[$0.configurationID] else { return false }
+                return config.mnemonic.strippingSettingsTransitionHash == requestedBase
+            }
+        }
         let contentBeingQueried: String
         switch strategy {
         case .swiftModule(_), .cHeader:
@@ -245,13 +256,12 @@ final class BazelTargetCompilerArgsExtractor {
                 return false
             }
         }
-        guard candidateActions.count > 0 else {
+        // After all filtering, multiple candidates means different ST variants
+        // for the same platform/file — compiler args are effectively identical.
+        guard let action = candidateActions.first else {
             throw BazelTargetCompilerArgsExtractorError.relevantTargetActionsNotFound(contentBeingQueried)
         }
-        guard candidateActions.count == 1 else {
-            throw BazelTargetCompilerArgsExtractorError.multipleTargetActions(contentBeingQueried, target.id)
-        }
-        return candidateActions[0]
+        return action
     }
 
     func clearCache() {
@@ -444,5 +454,19 @@ extension BazelTargetCompilerArgsExtractor {
             return
         }
         lines[idx + 1] = new
+    }
+}
+
+private extension String {
+    /// Strips the Bazel settings transition hash suffix from a configuration mnemonic.
+    ///
+    /// Bazel appends a `-ST-<hex>` suffix to configuration mnemonics to distinguish builds
+    /// that share the same platform/arch/minOS but have different build settings due to
+    /// different top-level targets (e.g., an app vs. an extension). The hash is deterministic
+    /// for a given set of settings but differs across top-level targets.
+    ///
+    /// See: https://bazel.build/extending/config#user-defined-transitions
+    var strippingSettingsTransitionHash: String {
+        self.replacingOccurrences(of: #"-ST-[a-f0-9]+$"#, with: "", options: .regularExpression)
     }
 }

--- a/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
+++ b/Tests/SourceKitBazelBSPTests/BazelTargetCompilerArgsExtractorTests.swift
@@ -229,6 +229,59 @@ struct BazelTargetCompilerArgsExtractorTests {
     }
 
     @Test
+    func swiftModuleWithDifferentSTHash() throws {
+        let extractor = Self.makeMockExtractor()
+        let testSourceUri = URI(
+            filePath: "/Users/user/Documents/demo-ios-project/HelloWorld/HelloWorldLib/Sources/AddTodoView.swift",
+            isDirectory: false
+        )
+        // Use a different ST hash than the one in the aquery (2842469f5300).
+        // This simulates a dependency that exists under multiple top-level targets
+        // where the cquery stored a different parent's config than the aquery has.
+        let differentSTConfig = BazelTargetConfigurationInfo(
+            configurationName: "ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-aaaaaaaaaaaa",
+            minimumOsVersion: "17.0",
+            platform: "iphonesimulator",
+            cpuArch: "sim_arm64",
+            sdkName: "iphonesimulator"
+        )
+        let result = try extractor.extractCompilerArgs(
+            fromAquery: aqueryResult,
+            forTarget: BazelTargetPlatformInfo(
+                label: "//HelloWorld:HelloWorldLib",
+                topLevelParentLabel: "//HelloWorld:HelloWorld",
+                topLevelParentConfig: differentSTConfig
+            ),
+            withStrategy: .swiftModule(testSourceUri),
+            indexOutputPath: nil
+        )
+        #expect(!result.isEmpty)
+    }
+
+    @Test
+    func objcFileWithDifferentSTHash() throws {
+        let extractor = Self.makeMockExtractor()
+        let differentSTConfig = BazelTargetConfigurationInfo(
+            configurationName: "ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-bbbbbbbbbbbb",
+            minimumOsVersion: "17.0",
+            platform: "iphonesimulator",
+            cpuArch: "sim_arm64",
+            sdkName: "iphonesimulator"
+        )
+        let result = try extractor.extractCompilerArgs(
+            fromAquery: aqueryResult,
+            forTarget: BazelTargetPlatformInfo(
+                label: "//HelloWorld:TodoObjCSupport",
+                topLevelParentLabel: "//HelloWorld:HelloWorld",
+                topLevelParentConfig: differentSTConfig
+            ),
+            withStrategy: .cImpl("HelloWorld/TodoObjCSupport/Sources/SKObjCUtils.m", "objective-c"),
+            indexOutputPath: nil
+        )
+        #expect(!result.isEmpty)
+    }
+
+    @Test
     func missingSwiftModule() throws {
         let extractor = Self.makeMockExtractor()
         let testSourceUri = URI(


### PR DESCRIPTION
## Fix config mismatch for targets under multiple top-level parents

### Problem

Each top-level target (app, extension, test) gets its own Bazel [settings transition](https://bazel.build/extending/config#user-defined-transitions) hash — the `-ST-<hex>` suffix in the configuration mnemonic (e.g., `ios_sim_arm64-dbg-ios-sim_arm64-min16.1-ST-90f37f7dbff2`).

A dependency shared between multiple top-level targets (e.g., a library used by both the main app and an extension) appears in the aquery result with the ST hash of whichever top-level target compiled it. However, `platformBuildLabelInfo` may return a *different* top-level target's config mnemonic (via `bspUriToParentConfigMap`), causing the exact mnemonic match in `getTargetAction` to fail.

This produces a continuous stream of `"No relevant target actions found for <target>. This is unexpected."` errors.

The issue affects both Swift and C/ObjC targets. Any dependency that exists under multiple top-level targets with different ST hashes can be affected — this includes common libraries, not just obscure external dependencies.

### Root cause

In `getTargetAction`, the config mnemonic filter requires an exact string match:

```swift
return config.mnemonic == platformInfo.topLevelParentConfig.configurationName
```

Two top-level targets with the same platform/arch/minOS but different build settings produce different ST hashes. The cquery and aquery may associate the same dependency with different top-level parents, creating a mismatch between the stored parent config and the available aquery actions.

### Fix

When the exact mnemonic match finds no candidates, fall back to matching with the `-ST-<hex>` suffix stripped. This preserves the platform/arch/minOS constraint while tolerating ST hash differences across top-level targets.

The fallback only runs when the exact match already returned zero results, so the happy path is unchanged. For C/ObjC files, the per-file `-c` argument filter runs *after* the fallback to ensure the correct source file is matched across all ST variants.

After all filtering, multiple remaining candidates are different ST variants of the same platform/file combination their compiler args are effectively identical, so we pick the first.

### Changes

- Added ST-hash fallback in `getTargetAction` when exact config mnemonic matching fails
- Replaced `multipleTargetActions` error with `candidateActions.first` — after the fallback + file filtering, remaining duplicates are benign ST variants
- Extracted `-ST-<hex>` stripping into `String.strippingSettingsTransitionHash` with documentation linking to the Bazel config transitions docs
